### PR TITLE
feat(quota): sync fallback when worker queue full — no more silent drops

### DIFF
--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -47,9 +47,16 @@ struct QuotaWorker {
     sender: tokio::sync::mpsc::Sender<QuotaTask>,
 }
 
+// Bigger queue: a 1k cap was tripping under modest burst load and
+// dropping billing events on the floor (try_send returned Err which
+// the previous `let _ = ` swallowed — see #27). 16k is generous for
+// the worst burst we expect; the sync fallback below catches anything
+// that still overflows so charges are NEVER lost silently.
+const QUOTA_QUEUE_CAPACITY: usize = 16_384;
+
 impl QuotaWorker {
     fn new(_pool: PgPool, num_workers: usize) -> Self {
-        let (tx, rx) = tokio::sync::mpsc::channel::<QuotaTask>(1000);
+        let (tx, rx) = tokio::sync::mpsc::channel::<QuotaTask>(QUOTA_QUEUE_CAPACITY);
         let rx = Arc::new(tokio::sync::Mutex::new(rx));
 
         for worker_id in 0..num_workers {
@@ -67,10 +74,14 @@ impl QuotaWorker {
                             if let Err(e) =
                                 quota_manager.charge_user(&task.user_id, task.cost).await
                             {
-                                eprintln!(
-                                    "[Worker {}] Failed to charge user {}: {}",
-                                    worker_id, task.user_id, e
+                                tracing::error!(
+                                    worker = worker_id,
+                                    user_id = %task.user_id,
+                                    cost = task.cost,
+                                    error = %e,
+                                    "quota charge failed in worker"
                                 );
+                                crate::metrics::QUOTA_LOST.inc();
                             }
                         }
                         None => break,
@@ -82,12 +93,51 @@ impl QuotaWorker {
         Self { sender: tx }
     }
 
-    fn charge(&self, user_id: String, cost: f64, pool: PgPool) {
-        let _ = self.sender.try_send(QuotaTask {
-            user_id,
+    /// Enqueue a charge for async processing. If the worker queue is full
+    /// we DO NOT drop the event silently (the previous behaviour would
+    /// have under-billed users — see #27). Instead we fall through to a
+    /// synchronous charge inline. This adds a small DB round-trip to the
+    /// user's request latency but guarantees correctness.
+    /// `QUOTA_SYNC_FALLBACKS` tracks how often this fires so SREs can
+    /// alert on sustained overflow and bump capacity.
+    async fn charge(&self, user_id: String, cost: f64, pool: PgPool) {
+        let depth = (QUOTA_QUEUE_CAPACITY - self.sender.capacity()) as i64;
+        crate::metrics::QUOTA_WORKER_QUEUE_DEPTH.set(depth.max(0));
+
+        match self.sender.try_send(QuotaTask {
+            user_id: user_id.clone(),
             cost,
-            pool,
-        });
+            pool: pool.clone(),
+        }) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                crate::metrics::QUOTA_SYNC_FALLBACKS.inc();
+                tracing::warn!(
+                    user_id = %user_id,
+                    cost,
+                    queue_depth = depth,
+                    "quota queue full, charging synchronously"
+                );
+                let quota_manager = mawi_core::quota::QuotaManager::new(pool);
+                if let Err(e) = quota_manager.charge_user(&user_id, cost).await {
+                    crate::metrics::QUOTA_LOST.inc();
+                    tracing::error!(
+                        user_id = %user_id,
+                        cost,
+                        error = %e,
+                        "synchronous quota fallback also failed — under-billing happened"
+                    );
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                crate::metrics::QUOTA_LOST.inc();
+                tracing::error!(
+                    user_id = %user_id,
+                    cost,
+                    "quota worker channel closed — under-billing happened"
+                );
+            }
+        }
     }
 }
 
@@ -1653,11 +1703,15 @@ impl Executor {
             },
         );
 
-        // Charge user via worker pool (bounded concurrency)
+        // Charge user via worker pool (bounded concurrency).
+        // `.charge` is async so it can fall back to a synchronous DB call
+        // when the worker queue overflows — this is what guarantees we
+        // never silently drop billing events.
         if let Some(cost) = cost_usd_owned {
             if let Some(uid) = user_id_owned.as_deref().or(key_id_owned.as_deref()) {
                 self.quota_worker
-                    .charge(uid.to_string(), cost, pool.clone());
+                    .charge(uid.to_string(), cost, pool.clone())
+                    .await;
             }
         }
     }

--- a/backend/gateway/src/metrics.rs
+++ b/backend/gateway/src/metrics.rs
@@ -152,7 +152,23 @@ lazy_static! {
     pub static ref QUOTA_WORKER_QUEUE_DEPTH: IntGauge = register_int_gauge_with_registry!(
         Opts::new("quota_worker_queue_depth", "Quota worker queue depth"),
         METRICS_REGISTRY.clone()
-    ).expect("Failed to register HTTP_REQUESTS_TOTAL metric");
+    ).expect("Failed to register QUOTA_WORKER_QUEUE_DEPTH metric");
+
+    /// Quota events that fell through to the synchronous fallback because
+    /// the async worker queue was full. Non-zero values mean we briefly
+    /// added latency to user requests to keep billing correct.
+    pub static ref QUOTA_SYNC_FALLBACKS: IntCounter = register_int_counter_with_registry!(
+        Opts::new("quota_sync_fallbacks_total", "Quota charges that took the synchronous fallback path"),
+        METRICS_REGISTRY.clone()
+    ).expect("Failed to register QUOTA_SYNC_FALLBACKS metric");
+
+    /// Quota events that failed even on the synchronous fallback (DB
+    /// down or similar). Anything > 0 here = under-billing happened —
+    /// alert on it.
+    pub static ref QUOTA_LOST: IntCounter = register_int_counter_with_registry!(
+        Opts::new("quota_lost_total", "Quota charges that could not be persisted (DB error)"),
+        METRICS_REGISTRY.clone()
+    ).expect("Failed to register QUOTA_LOST metric");
 
     // ============ MODEL EXECUTION METRICS ============
 


### PR DESCRIPTION
Closes #27 (CRITICAL — billing bypassable).

## Why
`QuotaWorker::charge` did `let _ = self.sender.try_send(...)` and silently dropped events whenever the 1000-cap channel filled. Under burst load → under-billing → revenue hole. The `QUOTA_WORKER_QUEUE_DEPTH` gauge was defined but never set, so SREs had no signal.

## What
- Channel cap **1000 → 16384**
- `charge()` now async; on `TrySendError::Full` falls through to a **synchronous** `charge_user(...).await` inline. Adds DB round-trip latency to the user but billing is correct.
- New metrics:
  - `quota_worker_queue_depth` — wired
  - `quota_sync_fallbacks_total` — incremented on every fallback
  - **`quota_lost_total`** — incremented if even the sync fallback fails. **Alert on > 0.**
- Worker error path uses `tracing::error!` with structured fields instead of `eprintln!` so it lands in the JSON log stream with request_id correlation.

## Note on #46
Audit-log durability is partially addressed via the existing LOG_DROPS counter (already wired). A follow-up will give RequestLogger the same sync-fallback pattern + a 'pending' table for the truly-degraded case.

## Test plan
- [x] cargo build --workspace clean
- [ ] Reviewer: under burst load, `quota_sync_fallbacks_total` may go up (expected). `quota_lost_total` should stay 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)