### PR TITLE
feat(audio): /v1/audio/music endpoint distinct from /v1/audio/speech

### DIFF
--- a/backend/core/src/providers/elevenlabs.rs
+++ b/backend/core/src/providers/elevenlabs.rs
@@ -3,10 +3,11 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::json;
 
-use crate::error::classify_response;
+use crate::error::{classify_reqwest_error, classify_response};
 use crate::providers::{ChatStream, ProviderAdapter};
 use crate::types::{
-    AudioTranscriptionRequest, ChatCompletionRequest, SpeechToSpeechRequest, TextToSpeechRequest,
+    AudioTranscriptionRequest, ChatCompletionRequest, MusicGenerationRequest, SpeechToSpeechRequest,
+    TextToSpeechRequest,
 };
 
 const PROVIDER: &str = "elevenlabs";
@@ -103,6 +104,54 @@ impl ProviderAdapter for ElevenLabsAdapter {
             .to_string();
 
         Ok(text)
+    }
+
+    /// ElevenLabs Music — `POST /v1/music`.
+    /// Body: `{ prompt, music_length_ms, model_id? }`.
+    /// Distinct from `/v1/text-to-speech/{voice_id}` (the TTS path):
+    /// no voice_id in the URL, no `text` field, takes a duration.
+    /// Returns audio/mpeg bytes.
+    async fn generate_music(
+        &self,
+        req: &MusicGenerationRequest,
+    ) -> Result<(String, Vec<u8>)> {
+        // ElevenLabs Music API accepts 10_000 to 300_000 ms. Default
+        // to 30s when the caller doesn't pin a length, matching the
+        // most common viral-short use case.
+        let music_length_ms = req.music_length_ms.unwrap_or(30_000).clamp(10_000, 300_000);
+
+        let mut body = json!({
+            "prompt": req.prompt,
+            "music_length_ms": music_length_ms,
+        });
+        // model_id is optional on this endpoint — only attach when the
+        // caller passed something other than a service name. Empty
+        // strings or service-name passthroughs produce upstream 400s,
+        // so we only forward values that look like real model ids.
+        if !req.model.is_empty() && !req.model.starts_with("music-") {
+            body.as_object_mut()
+                .unwrap()
+                .insert("model_id".to_string(), json!(req.model));
+        }
+
+        let response = self
+            .client
+            .post("https://api.elevenlabs.io/v1/music")
+            .header("xi-api-key", &self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| anyhow::Error::new(classify_reqwest_error(PROVIDER, e)))?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::Error::new(
+                classify_response(PROVIDER, response).await,
+            ));
+        }
+
+        let bytes = response.bytes().await?.to_vec();
+        Ok(("audio/mpeg".to_string(), bytes))
     }
 
     async fn speech_to_speech(

--- a/backend/core/src/providers/mod.rs
+++ b/backend/core/src/providers/mod.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     AudioTranscriptionRequest, ChatCompletionRequest, ImageGenerationRequest,
-    ImageGenerationResponse, SpeechToSpeechRequest, TextToSpeechRequest, VideoGenerationRequest,
-    VideoGenerationResponse,
+    ImageGenerationResponse, MusicGenerationRequest, SpeechToSpeechRequest, TextToSpeechRequest,
+    VideoGenerationRequest, VideoGenerationResponse,
 };
 use async_trait::async_trait;
 use std::pin::Pin;
@@ -62,6 +62,20 @@ pub trait ProviderAdapter: Send + Sync {
     ) -> Result<(String, Vec<u8>), anyhow::Error> {
         Err(anyhow::anyhow!(
             "Text-to-speech not supported by this provider"
+        ))
+    }
+
+    /// Generate music from a prompt (returns (content_type, bytes)).
+    /// Separate from text_to_speech because the upstream endpoints,
+    /// request bodies, and pricing all differ — folding them into one
+    /// trait method would force every TTS adapter to also handle music
+    /// (and vice versa) at the cost of clarity and correctness.
+    async fn generate_music(
+        &self,
+        _req: &MusicGenerationRequest,
+    ) -> Result<(String, Vec<u8>), anyhow::Error> {
+        Err(anyhow::anyhow!(
+            "Music generation not supported by this provider"
         ))
     }
 

--- a/backend/core/src/types.rs
+++ b/backend/core/src/types.rs
@@ -122,6 +122,27 @@ pub struct TextToSpeechRequest {
     pub voice: String,
 }
 
+/// Music generation request — distinct from TTS because the underlying
+/// endpoints diverge: ElevenLabs Music posts to `/v1/music` with
+/// `prompt` + `music_length_ms`, whereas TTS posts to
+/// `/v1/text-to-speech/{voice_id}` with `text`. Keeping them as
+/// separate request types in the gateway prevents accidentally
+/// routing a music call through the TTS handler (and vice versa)
+/// and keeps the OpenAPI schema honest.
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
+pub struct MusicGenerationRequest {
+    /// Creative direction for the track ("uplifting cinematic intro,
+    /// 90 BPM, swelling strings"). Required.
+    pub prompt: String,
+    /// Gateway service or model id.
+    pub model: String,
+    /// Track length in milliseconds. ElevenLabs accepts 10_000 to
+    /// 300_000. Defaults to 30_000 when caller leaves it unset.
+    #[serde(default)]
+    pub music_length_ms: Option<u32>,
+}
+
 /// Speech-to-text (transcription) request
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]

--- a/backend/gateway/src/audio.rs
+++ b/backend/gateway/src/audio.rs
@@ -1,6 +1,6 @@
 use crate::executor::Executor;
 use crate::idempotency::{self, IdempotencyDecision};
-use mawi_core::types::TextToSpeechRequest;
+use mawi_core::types::{MusicGenerationRequest, TextToSpeechRequest};
 use poem::{
     handler,
     http::StatusCode,
@@ -71,6 +71,93 @@ pub async fn text_to_speech(
         .await
         .map_err(|e| {
             tracing::warn!(error = %e, "TTS failed");
+            mawi_core::error::into_poem_error(e)
+        })?;
+
+    if let Some(ref key) = idem_key {
+        if let Err(e) = idempotency::record(
+            pool.0,
+            &user_id,
+            key,
+            &request_hash,
+            200,
+            &bytes,
+            Some(&content_type),
+        )
+        .await
+        {
+            tracing::warn!(user_id = %user_id, error = %e, "idempotency record failed");
+        }
+    }
+
+    Ok(Response::builder()
+        .content_type(content_type)
+        .body(Body::from(bytes)))
+}
+
+/// Music generation handler — `POST /v1/audio/music`.
+/// Mirrors the TTS handler's contract (auth, idempotency, binary
+/// audio response) but takes a MusicGenerationRequest and routes to
+/// `executor.execute_music_generation`. Different endpoint from
+/// `/v1/audio/speech` because the upstream provider APIs diverge:
+/// ElevenLabs Music posts to `/v1/music` with prompt + length while
+/// TTS posts to `/v1/text-to-speech/{voice_id}` with text + voice.
+#[handler]
+pub async fn generate_music(
+    req_http: &poem::Request,
+    req: Json<MusicGenerationRequest>,
+    executor: Data<&Arc<Executor>>,
+    pool: Data<&PgPool>,
+) -> poem::Result<Response> {
+    let user = req_http
+        .extensions()
+        .get::<mawi_core::auth::User>()
+        .ok_or_else(|| {
+            poem::Error::from_string("Authentication required", StatusCode::UNAUTHORIZED)
+        })?;
+    let user_id = user.id.clone();
+
+    eprintln!("🎵 Music Request for model: {}", req.model);
+
+    let idem_key = idempotency::header_from_request(req_http)?;
+    let body_bytes = serde_json::to_vec(&req.0).map_err(|e| {
+        poem::Error::from_string(
+            format!("could not re-serialise request for idempotency hash: {}", e),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
+    let request_hash = idempotency::hash_request("POST", "/v1/audio/music", &body_bytes);
+
+    if let Some(ref key) = idem_key {
+        match idempotency::check(pool.0, &user_id, Some(key), &request_hash).await {
+            Ok(IdempotencyDecision::Cached {
+                response_body,
+                content_type,
+                ..
+            }) => {
+                let ct = content_type.unwrap_or_else(|| "audio/mpeg".to_string());
+                return Ok(Response::builder()
+                    .content_type(ct)
+                    .body(Body::from(response_body)));
+            }
+            Ok(IdempotencyDecision::Mismatch) => {
+                return Err(poem::Error::from_string(
+                    "idempotency-key reuse with a different request body",
+                    StatusCode::CONFLICT,
+                ));
+            }
+            Ok(IdempotencyDecision::Fresh) | Ok(IdempotencyDecision::NoKey) => {}
+            Err(e) => {
+                tracing::warn!(user_id = %user_id, error = %e, "idempotency check failed; proceeding without cache");
+            }
+        }
+    }
+
+    let (content_type, bytes) = executor
+        .execute_music_generation(&req.0, &user.id)
+        .await
+        .map_err(|e| {
+            tracing::warn!(error = %e, "music generation failed");
             mawi_core::error::into_poem_error(e)
         })?;
 

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -435,6 +435,50 @@ impl Executor {
         Ok(result)
     }
 
+    /// Execute music generation request. Routes through the standard
+    /// model-resolution → adapter → circuit-breaker pipeline like the
+    /// other audio paths; the only difference is the trait method
+    /// (`generate_music`) and the cost model (per-second).
+    pub async fn execute_music_generation(
+        &self,
+        request: &mawi_core::types::MusicGenerationRequest,
+        user_id: &str,
+    ) -> Result<(String, Vec<u8>)> {
+        let music_length_ms = request.music_length_ms.unwrap_or(30_000);
+        let estimated_cost =
+            crate::pricing::PRICING.get_music_cost(&request.model, music_length_ms);
+        let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
+        quota_manager
+            .check_quota(user_id, 0.01_f64.max(estimated_cost))
+            .await?;
+
+        let model = self.get_model(&request.model).await?;
+        let provider = self.get_provider(&model.provider).await?;
+        let adapter = self.create_adapter(&provider, &model)?;
+
+        // Same model-name rewrite as TTS — forward upstream model id,
+        // not the gateway-internal one.
+        let upstream_req = mawi_core::types::MusicGenerationRequest {
+            prompt: request.prompt.clone(),
+            model: model.name.clone(),
+            music_length_ms: request.music_length_ms,
+        };
+
+        let result = self
+            .with_breaker(&model.id, || async {
+                adapter.generate_music(&upstream_req).await
+            })
+            .await?;
+
+        if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
+            warn!(error = %e, user_id, "failed to charge user for music generation");
+        } else {
+            debug!(cost = estimated_cost, user_id, "charged for music generation");
+        }
+
+        Ok(result)
+    }
+
     /// Execute speech-to-text (transcription) request
     pub async fn execute_transcription(
         &self,

--- a/backend/gateway/src/main.rs
+++ b/backend/gateway/src/main.rs
@@ -221,6 +221,13 @@ async fn main() -> Result<(), anyhow::Error> {
             "/v1/audio/speech",
             post(audio::text_to_speech).data(executor.clone()),
         )
+        // Music generation endpoint — distinct from /v1/audio/speech
+        // because the upstream provider APIs diverge (ElevenLabs Music
+        // uses /v1/music with prompt + music_length_ms, no voice id).
+        .at(
+            "/v1/audio/music",
+            post(audio::generate_music).data(executor.clone()),
+        )
         // Speech-to-text endpoint
         .at(
             "/v1/audio/transcriptions",

--- a/backend/gateway/src/pricing.rs
+++ b/backend/gateway/src/pricing.rs
@@ -182,6 +182,16 @@ impl PricingData {
         // Fixed estimate per video generation
         0.10
     }
+
+    pub fn get_music_cost(&self, _model: &str, music_length_ms: u32) -> f64 {
+        // ElevenLabs Music charges per second of generated audio.
+        // Their published rate is roughly 1000 credits per minute on
+        // the Creator tier (~$0.08/min equivalent). Use a flat
+        // $0.0014/sec estimate so the quota pre-check is conservative
+        // without over-charging short clips.
+        let seconds = (music_length_ms as f64) / 1000.0;
+        seconds * 0.0014
+    }
 }
 
 // Global pricing instance


### PR DESCRIPTION
## Summary
Voice and music are different upstream APIs and were being conflated. ElevenLabs Music posts to \`/v1/music\` with \`{prompt, music_length_ms}\`; TTS posts to \`/v1/text-to-speech/{voice_id}\` with \`{text, voice}\`. Routing music through the TTS handler would have either flat-tone-read-aloud the prompt or 400'd on the missing voice_id.

## What's new
- \`MusicGenerationRequest\` type in \`core::types\` (prompt + model + optional \`music_length_ms\`, default 30s, clamped 10–300s)
- \`ProviderAdapter::generate_music\` trait method (default returns "not supported" so existing adapters compile clean)
- ElevenLabs implementation hits \`POST /v1/music\` — forwards \`model_id\` only when caller passed a real model id (gateway passthroughs like \`music-default\` produce upstream 400s otherwise)
- \`Executor::execute_music_generation\` mirrors the TTS executor (quota check → model resolve → adapter → breaker → charge) with a per-second cost estimate
- \`audio::generate_music\` handler with the same auth + idempotency envelope as TTS
- \`POST /v1/audio/music\` route registered

## Test plan
- [ ] \`cargo build\` clean
- [ ] \`cargo test -p mawi-core --test provider_adapters\` → 14 pass
- [ ] Configure ElevenLabs key, hit \`POST /v1/audio/music\` with \`{"model":"eleven-music","prompt":"uplifting cinematic intro 90 BPM"}\` → returns audio/mpeg ≥ 30s of audio
- [ ] Hit with \`music_length_ms: 5000\` → request still succeeds, length clamped to 10s upstream
- [ ] Hit \`/v1/audio/speech\` → still works, unchanged

## Follow-up
viralstory#9 still needs the frontend \`mawi.synthesizeMusic\` client call + replacement of \`generateBackgroundMusic: STUB(...)\` in \`functionsAdapter.js\`. Will land in a separate PR once this merges.