### PR TITLE
fix: service-name resolution + DALL-E adapter + Sora duration clamp

### DIFF
--- a/backend/core/src/error.rs
+++ b/backend/core/src/error.rs
@@ -213,41 +213,102 @@ pub async fn classify_response(provider: &str, response: reqwest::Response) -> P
         .and_then(|s| s.parse::<u64>().ok())
         .map(Duration::from_secs);
     let body = response.text().await.unwrap_or_default();
-    let snippet = truncate(&body, 512);
+    let message = extract_provider_message(&body);
 
     match status.as_u16() {
         400 | 422 => ProviderError::BadRequest {
             provider: provider.to_string(),
-            message: snippet,
+            message,
         },
         401 | 403 => ProviderError::Unauthorized {
             provider: provider.to_string(),
-            message: snippet,
+            message,
         },
         408 => ProviderError::Timeout {
             provider: provider.to_string(),
-            message: snippet,
+            message,
         },
         429 => ProviderError::RateLimit {
             provider: provider.to_string(),
             retry_after,
-            message: snippet,
+            message,
         },
         502 | 503 | 504 => ProviderError::Unavailable {
             provider: provider.to_string(),
             retry_after,
-            message: snippet,
+            message,
         },
         s if s >= 500 => ProviderError::Internal {
             provider: provider.to_string(),
             status: s,
-            message: snippet,
+            message,
         },
         _ => ProviderError::Other {
             provider: provider.to_string(),
-            message: format!("HTTP {status}: {snippet}"),
+            message: format!("HTTP {status}: {message}"),
         },
     }
+}
+
+/// Extract the actionable message from a provider's error body.
+/// All major providers return JSON like
+///     `{"error": {"message": "...", "code": "..."}}`
+/// (OpenAI, Anthropic, Mistral, Gemini, Cohere)
+/// or
+///     `{"error": "..."}` (Runway, Kling, smaller providers)
+/// or just a plain string. Falls back to the (truncated) raw body
+/// when the structure is unrecognised so we never lose information.
+///
+/// The point: surface the bit a human can act on instead of forcing
+/// the operator to wade through 400 chars of nested JSON.
+fn extract_provider_message(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "<empty response body>".to_string();
+    }
+
+    // Try JSON. If it doesn't parse, the body's likely already a
+    // human-readable string — return it (truncated).
+    let json: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(_) => return truncate(trimmed, 512),
+    };
+
+    // OpenAI / Anthropic / Mistral / Cohere shape:
+    //   { "error": { "message": "...", "type": "...", "code": "..." } }
+    if let Some(err) = json.get("error") {
+        if let Some(msg) = err.get("message").and_then(|m| m.as_str()) {
+            // Append code/type when present — they're often actionable
+            // ("insufficient_quota", "model_not_found", "context_length_exceeded").
+            let code = err
+                .get("code")
+                .and_then(|c| c.as_str())
+                .or_else(|| err.get("type").and_then(|t| t.as_str()));
+            return match code {
+                Some(c) if !c.is_empty() => format!("{} [{}]", msg, c),
+                _ => msg.to_string(),
+            };
+        }
+        // {"error": "string"} (Runway, Kling, etc.)
+        if let Some(s) = err.as_str() {
+            return s.to_string();
+        }
+    }
+
+    // Gemini shape: { "error": { "code": 401, "message": "...", "status": "..." } }
+    // already handled by the branch above (it has `message`).
+
+    // Top-level "message" (some providers) or "detail" (FastAPI)
+    if let Some(s) = json.get("message").and_then(|m| m.as_str()) {
+        return s.to_string();
+    }
+    if let Some(s) = json.get("detail").and_then(|m| m.as_str()) {
+        return s.to_string();
+    }
+
+    // Unknown JSON shape — fall back to truncated raw so we still
+    // surface something rather than losing it.
+    truncate(trimmed, 512)
 }
 
 /// Classify a `reqwest::Error` (network / TLS / timeout) into ProviderError.

--- a/backend/core/src/error.rs
+++ b/backend/core/src/error.rs
@@ -272,8 +272,19 @@ pub fn classify_reqwest_error(provider: &str, err: reqwest::Error) -> ProviderEr
 }
 
 /// Try to extract a `ProviderError` from an opaque `anyhow::Error`.
+/// Walks the error chain so a `.context()`-wrapped `ProviderError`
+/// (e.g. `e.context("Provider API error")` from the executor's
+/// failover loop) still resolves correctly.
 pub fn downcast(err: &anyhow::Error) -> Option<&ProviderError> {
-    err.downcast_ref::<ProviderError>()
+    if let Some(pe) = err.downcast_ref::<ProviderError>() {
+        return Some(pe);
+    }
+    for cause in err.chain() {
+        if let Some(pe) = cause.downcast_ref::<ProviderError>() {
+            return Some(pe);
+        }
+    }
+    None
 }
 
 /// Convert an opaque `anyhow::Error` from a provider call into a Poem error

--- a/backend/core/src/providers/openai.rs
+++ b/backend/core/src/providers/openai.rs
@@ -117,6 +117,45 @@ impl ProviderAdapter for OpenAIAdapter {
         Ok(Box::pin(parsed_stream))
     }
 
+    async fn generate_image(
+        &self,
+        req: &crate::types::ImageGenerationRequest,
+    ) -> Result<crate::types::ImageGenerationResponse, anyhow::Error> {
+        // DALL-E / gpt-image. Endpoint: POST /v1/images/generations.
+        // Body shape mirrors OpenAI's published spec — model/prompt
+        // required, n + size optional (defaults 1024x1024 if omitted).
+        let mut body = serde_json::json!({
+            "model": req.model,
+            "prompt": req.prompt,
+            "n": req.n,
+            "size": req.size,
+        });
+        if let Some(q) = &req.quality {
+            body.as_object_mut().unwrap().insert("quality".into(), serde_json::json!(q));
+        }
+        if let Some(s) = &req.style {
+            body.as_object_mut().unwrap().insert("style".into(), serde_json::json!(s));
+        }
+
+        let response = self
+            .client
+            .post(format!("{}/images/generations", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::Error::new(
+                classify_response(PROVIDER, response).await,
+            ));
+        }
+
+        let img_response: crate::types::ImageGenerationResponse = response.json().await?;
+        Ok(img_response)
+    }
+
     async fn generate_video(
         &self,
         req: &crate::types::VideoGenerationRequest,
@@ -124,9 +163,18 @@ impl ProviderAdapter for OpenAIAdapter {
         #[cfg(debug_assertions)]
         eprintln!("🎬 OpenAI Sora video generation - model: {}", req.model);
 
-        // Parse size and duration (OpenAI supports 4, 8, or 12 seconds)
         let size = req.size.clone().unwrap_or_else(|| "1280x720".to_string());
-        let duration = req.duration.unwrap_or(8).to_string(); // Default to 8 seconds
+        // Sora 2 only accepts {4, 8, 12} seconds — anything else 400s
+        // with `Invalid value: '5'. Supported values are: '4', '8',
+        // and '12'.` Snap the caller's request to the nearest valid
+        // value so the canvas can keep speaking in arbitrary seconds.
+        let requested = req.duration.unwrap_or(8) as i32;
+        let duration = [4_i32, 8, 12]
+            .iter()
+            .min_by_key(|&&v| (v - requested).abs())
+            .copied()
+            .unwrap_or(8)
+            .to_string();
 
         // OpenAI Sora uses multipart/form-data
         let form = reqwest::multipart::Form::new()

--- a/backend/core/src/providers/openai.rs
+++ b/backend/core/src/providers/openai.rs
@@ -176,9 +176,24 @@ impl ProviderAdapter for OpenAIAdapter {
             .unwrap_or(8)
             .to_string();
 
-        // OpenAI Sora uses multipart/form-data
+        // Sora 2's image-to-video path requires a previously-uploaded
+        // file referenced as `{"type":"image","file_id":"file-…"}`,
+        // NOT a raw multipart attachment under `input_reference` —
+        // direct-attach returns
+        //   "Invalid type for 'input_reference': expected an object,
+        //    but got a file instead."
+        // Threading the two-step (POST /v1/files → POST /v1/videos
+        // with file_id) flow is its own change tracked separately.
+        // Until that lands, fold any caller-supplied reference URL
+        // into the prompt so the narrative context still reaches Sora.
+        let prompt_with_ref = match req.input_image_url.as_deref() {
+            Some(url) => format!("{}\n\nReference image: {}", req.prompt, url),
+            None => req.prompt.clone(),
+        };
+
+        // OpenAI Sora uses multipart/form-data.
         let form = reqwest::multipart::Form::new()
-            .text("prompt", req.prompt.clone())
+            .text("prompt", prompt_with_ref)
             .text("model", req.model.clone())
             .text("size", size)
             .text("seconds", duration);

--- a/backend/core/src/providers/openai.rs
+++ b/backend/core/src/providers/openai.rs
@@ -163,7 +163,22 @@ impl ProviderAdapter for OpenAIAdapter {
         #[cfg(debug_assertions)]
         eprintln!("🎬 OpenAI Sora video generation - model: {}", req.model);
 
-        let size = req.size.clone().unwrap_or_else(|| "1280x720".to_string());
+        // Sora 2 only accepts 720x1280 or 1280x720. Anything else 400s
+        // with `Invalid size for sora-2 model, only 720x1280, 1280x720
+        // are supported.` ViralStory's canvas thinks in 9:16 / 16:9 /
+        // 1:1 × 720p/1080p/4k, so any non-Sora multiple shows up here.
+        // Snap to the closer aspect — taller-than-wide → 720x1280,
+        // anything else → 1280x720.
+        let requested_size = req.size.clone().unwrap_or_else(|| "1280x720".to_string());
+        let size = match requested_size.split_once('x') {
+            Some((w, h)) => {
+                let w: u32 = w.parse().unwrap_or(1280);
+                let h: u32 = h.parse().unwrap_or(720);
+                if h > w { "720x1280".to_string() } else { "1280x720".to_string() }
+            }
+            None => "1280x720".to_string(),
+        };
+
         // Sora 2 only accepts {4, 8, 12} seconds — anything else 400s
         // with `Invalid value: '5'. Supported values are: '4', '8',
         // and '12'.` Snap the caller's request to the nearest valid

--- a/backend/core/src/types.rs
+++ b/backend/core/src/types.rs
@@ -78,7 +78,7 @@ pub struct Delta {
 }
 
 /// Image generation request
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
 pub struct ImageGenerationRequest {
     pub prompt: String,
@@ -114,7 +114,7 @@ pub struct ImageData {
 }
 
 /// Text-to-speech request
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
 pub struct TextToSpeechRequest {
     pub input: String,
@@ -123,7 +123,7 @@ pub struct TextToSpeechRequest {
 }
 
 /// Speech-to-text (transcription) request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
 pub struct AudioTranscriptionRequest {
     pub model: String,
@@ -139,7 +139,7 @@ pub struct AudioTranscriptionResponse {
 }
 
 /// Speech-to-speech request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
 pub struct SpeechToSpeechRequest {
     pub model: String,

--- a/backend/core/src/types.rs
+++ b/backend/core/src/types.rs
@@ -148,7 +148,7 @@ pub struct SpeechToSpeechRequest {
 }
 
 /// Video generation request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[cfg_attr(feature = "openapi", derive(poem_openapi::Object))]
 pub struct VideoGenerationRequest {
     pub prompt: String,
@@ -157,6 +157,18 @@ pub struct VideoGenerationRequest {
     pub size: Option<String>, // e.g., "1280x720", "1920x1080"
     #[serde(default)]
     pub duration: Option<u32>, // Duration in seconds
+    /// First-frame conditioning. The gateway fetches this URL
+    /// server-side and forwards it to the upstream provider as a
+    /// multipart `input_reference` (Sora 2), `init_image` (Veo), or
+    /// `image_url` (Runway). Optional — providers fall back to pure
+    /// text-to-video when absent.
+    #[serde(default)]
+    pub input_image_url: Option<String>,
+    /// Extension / re-cut source. Forwarded to providers that accept
+    /// a video-to-video or extension input (Runway, Pika, Luma).
+    /// Optional.
+    #[serde(default)]
+    pub input_video_url: Option<String>,
 }
 
 /// Video generation response

--- a/backend/core/tests/provider_adapters.rs
+++ b/backend/core/tests/provider_adapters.rs
@@ -270,6 +270,8 @@ fn request_types_are_publicly_constructable() {
         model: "m".into(),
         size: Some("1280x720".into()),
         duration: Some(5),
+        input_image_url: None,
+        input_video_url: None,
     };
     let _tts = TextToSpeechRequest {
         input: "hi".into(),

--- a/backend/gateway/src/agentic_executor.rs
+++ b/backend/gateway/src/agentic_executor.rs
@@ -2033,7 +2033,7 @@ impl AgenticExecutor {
             input_video_url: None,
         };
 
-        let response = self
+        let (_chosen_model, response) = self
             .executor
             .execute_video_generation(&request, user_id)
             .await?;

--- a/backend/gateway/src/agentic_executor.rs
+++ b/backend/gateway/src/agentic_executor.rs
@@ -2029,6 +2029,8 @@ impl AgenticExecutor {
             prompt: prompt.to_string(),
             size: Some("1280x720".to_string()),
             duration: Some(8),
+            input_image_url: None,
+            input_video_url: None,
         };
 
         let response = self

--- a/backend/gateway/src/api.rs
+++ b/backend/gateway/src/api.rs
@@ -2276,14 +2276,38 @@ pub async fn compute_and_update_service_capabilities(
         }
     };
 
+    // pool_type — derive from the modality count, so the admin UI can
+    // honestly label single-modality vs multi-modality pools. Counts
+    // distinct upstream modalities (text, image, video, audio); if the
+    // pool spans more than one, it's multi-modality. Stays NULL when
+    // the pool has no models yet so we don't claim either label.
+    let modality_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(DISTINCT m.modality)
+         FROM service_models sm
+         JOIN models m ON sm.model_id = m.id
+         WHERE sm.service_name = $1
+         AND m.modality IS NOT NULL",
+    )
+    .bind(service_name)
+    .fetch_one(pool)
+    .await
+    .unwrap_or(0);
+
+    let pool_type: Option<&str> = match modality_count {
+        0 => None,
+        1 => Some("SINGLE_MODALITY"),
+        _ => Some("MULTI_MODALITY"),
+    };
+
     sqlx::query(
         "UPDATE services
-         SET input_modalities = $1, output_modalities = $2
+         SET input_modalities = $1, output_modalities = $2, pool_type = COALESCE($4, pool_type)
          WHERE name = $3",
     )
     .bind(to_json(input_set))
     .bind(to_json(output_set))
     .bind(service_name)
+    .bind(pool_type)
     .execute(pool)
     .await?;
 

--- a/backend/gateway/src/api.rs
+++ b/backend/gateway/src/api.rs
@@ -1794,84 +1794,20 @@ impl ModelsApi {
         )))
     }
 
-    /// Helper: Auto-detect and update service input/output modalities from assigned models
+    /// Wraps the free `compute_and_update_service_capabilities` so the
+    /// existing #[OpenApi] handlers keep their `poem::Result<()>` shape.
+    /// External callers (config_loader, boot-time backfill) should use
+    /// the free function directly with `anyhow::Result<()>`.
     async fn update_service_capabilities(&self, service_name: &str) -> poem::Result<()> {
-        use std::collections::HashSet;
-
-        // Query all models assigned to this service with their modality
-        let models: Vec<String> = sqlx::query_scalar(
-            "SELECT DISTINCT m.modality 
-             FROM service_models sm
-             JOIN models m ON sm.model_id = m.id
-             WHERE sm.service_name = $1
-             AND m.modality IS NOT NULL",
-        )
-        .bind(service_name)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|e| {
-            poem::error::Error::from_string(
-                format!("Failed to query service models: {}", e),
-                poem::http::StatusCode::INTERNAL_SERVER_ERROR,
-            )
-        })?;
-
-        let mut input_set = HashSet::new();
-        let mut output_set = HashSet::new();
-
-        for mod_str in models {
-            let m = mod_str.to_lowercase();
-            if m.contains("text") {
-                input_set.insert("text".to_string());
-                output_set.insert("text".to_string());
-            } else if m.contains("image") {
-                input_set.insert("text".to_string()); // Prompt
-                output_set.insert("image".to_string());
-            } else if m.contains("video") {
-                input_set.insert("text".to_string()); // Prompt
-                output_set.insert("video".to_string());
-            } else if m.contains("audio") {
-                input_set.insert("text".to_string());
-                output_set.insert("audio".to_string());
-                input_set.insert("audio".to_string()); // Support both directions slightly ambiguously to be safe
-            } else {
-                // Fallback
-                input_set.insert(m.clone());
-                output_set.insert(m);
-            }
-        }
-
-        // Convert to JSON array
-        let to_json = |set: HashSet<String>| -> Option<String> {
-            if set.is_empty() {
-                None
-            } else {
-                let mut sorted: Vec<String> = set.into_iter().collect();
-                sorted.sort();
-                Some(serde_json::to_string(&sorted).unwrap_or_else(|_| "[]".to_string()))
-            }
-        };
-
-        sqlx::query(
-            "UPDATE services 
-             SET input_modalities = $1, output_modalities = $2
-             WHERE name = $3",
-        )
-        .bind(to_json(input_set))
-        .bind(to_json(output_set))
-        .bind(service_name)
-        .execute(&self.pool)
-        .await
-        .map_err(|e| {
-            poem::error::Error::from_string(
-                format!("Failed to update service capabilities: {}", e),
-                poem::http::StatusCode::INTERNAL_SERVER_ERROR,
-            )
-        })?;
-
-        Ok(())
+        compute_and_update_service_capabilities(&self.pool, service_name)
+            .await
+            .map_err(|e| {
+                poem::error::Error::from_string(
+                    format!("Failed to update service capabilities: {}", e),
+                    poem::http::StatusCode::INTERNAL_SERVER_ERROR,
+                )
+            })
     }
-
     /// Helper: Reorder service models by weight descending
     async fn reorder_service_models_by_weight(&self, service_name: &str) -> poem::Result<()> {
         #[derive(sqlx::FromRow)]
@@ -2249,4 +2185,129 @@ impl ModelsApi {
 
         Ok(Json("MCP server removed from service".to_string()))
     }
+}
+
+/// Auto-derive a service's `input_modalities` / `output_modalities`
+/// from the modalities of the models in its pool, then update the
+/// `services` row.
+///
+/// The model's `modality` field tells us what *medium* the model
+/// works with (audio, image, video, text); the service NAME tells us
+/// the *direction*. This matters most for audio: a `voice-*` service
+/// speaks text → audio (TTS); a `transcribe-*` service listens
+/// audio → text (STT). Without the name disambiguation we used to
+/// surface both directions for every audio model, which made the
+/// admin UI show `IN text + audio  OUT text + audio` for pure TTS
+/// pools.
+///
+/// Idempotent — call any number of times for the same service.
+/// Used by the OpenAPI handlers AND by the seed-loader / boot-time
+/// backfill so services land with correct modalities regardless of
+/// how they were created.
+pub async fn compute_and_update_service_capabilities(
+    pool: &sqlx::PgPool,
+    service_name: &str,
+) -> anyhow::Result<()> {
+    use std::collections::HashSet;
+
+    let models: Vec<String> = sqlx::query_scalar(
+        "SELECT DISTINCT m.modality
+         FROM service_models sm
+         JOIN models m ON sm.model_id = m.id
+         WHERE sm.service_name = $1
+         AND m.modality IS NOT NULL",
+    )
+    .bind(service_name)
+    .fetch_all(pool)
+    .await?;
+
+    let name = service_name.to_lowercase();
+    let is_transcribe = name.starts_with("transcribe") || name.starts_with("stt");
+    let is_voice = name.starts_with("voice")
+        || name.starts_with("tts")
+        || name.starts_with("speech");
+    let is_music = name.starts_with("music");
+    let is_speech_to_speech = name.contains("speech-to-speech") || name.contains("sts");
+
+    let mut input_set: HashSet<String> = HashSet::new();
+    let mut output_set: HashSet<String> = HashSet::new();
+
+    for mod_str in models {
+        let m = mod_str.to_lowercase();
+        if m.contains("text") {
+            input_set.insert("text".into());
+            output_set.insert("text".into());
+        } else if m.contains("image") {
+            input_set.insert("text".into());
+            output_set.insert("image".into());
+        } else if m.contains("video") {
+            input_set.insert("text".into());
+            output_set.insert("video".into());
+        } else if m.contains("audio") {
+            if is_speech_to_speech {
+                input_set.insert("audio".into());
+                output_set.insert("audio".into());
+            } else if is_transcribe {
+                input_set.insert("audio".into());
+                output_set.insert("text".into());
+            } else if is_voice || is_music {
+                input_set.insert("text".into());
+                output_set.insert("audio".into());
+            } else {
+                // Unknown direction — keep the legacy behaviour
+                // (both sides) rather than silently picking wrong.
+                input_set.insert("text".into());
+                input_set.insert("audio".into());
+                output_set.insert("audio".into());
+            }
+        } else {
+            input_set.insert(m.clone());
+            output_set.insert(m);
+        }
+    }
+
+    let to_json = |set: HashSet<String>| -> Option<String> {
+        if set.is_empty() {
+            None
+        } else {
+            let mut sorted: Vec<String> = set.into_iter().collect();
+            sorted.sort();
+            Some(serde_json::to_string(&sorted).unwrap_or_else(|_| "[]".to_string()))
+        }
+    };
+
+    sqlx::query(
+        "UPDATE services
+         SET input_modalities = $1, output_modalities = $2
+         WHERE name = $3",
+    )
+    .bind(to_json(input_set))
+    .bind(to_json(output_set))
+    .bind(service_name)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Boot-time backfill — recompute and store modalities for every
+/// service in the DB. Called once from main.rs so already-seeded
+/// rows pick up the corrected logic without an admin-UI round-trip.
+pub async fn backfill_all_service_capabilities(pool: &sqlx::PgPool) -> anyhow::Result<()> {
+    let names: Vec<String> = sqlx::query_scalar("SELECT name FROM services")
+        .fetch_all(pool)
+        .await?;
+    let mut ok = 0_usize;
+    let mut errs = 0_usize;
+    for name in &names {
+        match compute_and_update_service_capabilities(pool, name).await {
+            Ok(()) => ok += 1,
+            Err(e) => {
+                tracing::warn!(service = %name, error = %e, "modality backfill failed");
+                errs += 1;
+            }
+        }
+    }
+    tracing::info!(ok, errs, total = names.len(), "service modality backfill complete");
+    Ok(())
 }

--- a/backend/gateway/src/chat_new.rs
+++ b/backend/gateway/src/chat_new.rs
@@ -35,6 +35,16 @@ enum ChatResponse {
     Forbidden(Json<OpenAiErrorResponse>),
     #[oai(status = 409)]
     IdempotencyMismatch(Json<OpenAiErrorResponse>),
+    /// 429 — at least one upstream provider rate-limited us. Body
+    /// carries the upstream message (e.g. "insufficient_quota") so the
+    /// caller can tell whether to back off or top up billing.
+    #[oai(status = 429)]
+    TooManyRequests(Json<OpenAiErrorResponse>),
+    /// 503 — every healthy model in the pool is currently unavailable
+    /// (5xx / connection errors / circuit-breaker tripped). Caller
+    /// should retry after a delay.
+    #[oai(status = 503)]
+    ServiceUnavailable(Json<OpenAiErrorResponse>),
     #[oai(status = 500)]
     InternalError(Json<OpenAiErrorResponse>),
 }
@@ -301,12 +311,26 @@ impl ChatApi {
                 // but not 5xx; we keep it simple — no recording for any
                 // error path until a clear use case demands otherwise.)
                 eprintln!("Chat execution failed: {}", e);
-                // The executor may have raised because the service was
-                // unknown (404-shape) vs an actual upstream API failure.
-                // Without typed error info from execute_chat we can't
-                // tell here — surface as `api_error` (5xx) so SDKs raise
-                // openai.APIError, which is the right class for
-                // "something went wrong server-side, retry maybe."
+                // Try to recover the typed ProviderError that bubbled up
+                // from the failover loop. When every model in the pool
+                // hit the same upstream failure (e.g. all OpenAI keys
+                // out of quota), this lets the response carry the right
+                // 4xx (rate_limit / unauthorized / bad_request) instead
+                // of a generic 500 — clients can react meaningfully and
+                // the user sees "your OpenAI quota ran out" instead of
+                // "internal server error".
+                if let Some(pe) = mawi_core::error::downcast(&e) {
+                    use mawi_core::error::ProviderError;
+                    let body = OpenAiError::new(pe.message().to_string(), error_type::API);
+                    return match pe {
+                        ProviderError::RateLimit { .. } => ChatResponse::TooManyRequests(Json(body)),
+                        ProviderError::Unauthorized { .. } => ChatResponse::Unauthorized(Json(body)),
+                        ProviderError::BadRequest { .. } => ChatResponse::BadRequest(Json(body)),
+                        ProviderError::Unavailable { .. } => ChatResponse::ServiceUnavailable(Json(body)),
+                        ProviderError::Timeout { .. } => ChatResponse::ServiceUnavailable(Json(body)),
+                        _ => ChatResponse::InternalError(Json(body)),
+                    };
+                }
                 ChatResponse::InternalError(Json(OpenAiError::new(
                     format!("Request failed: {}", e),
                     error_type::API,

--- a/backend/gateway/src/config_loader.rs
+++ b/backend/gateway/src/config_loader.rs
@@ -130,6 +130,16 @@ pub async fn apply_config(cfg: &GatewayConfig, pool: &PgPool) -> Result<UpsertCo
         // change together.
         let svc_models_written = replace_service_models(&s.name, &s.models, pool).await?;
         counts.service_models += svc_models_written;
+
+        // Re-derive the service's input/output modalities from the
+        // models we just bound. Without this the row keeps the
+        // default `["text"] -> ["text"]` and the admin UI shows
+        // wrong arrows for voice / transcribe / image / video pools.
+        if let Err(e) =
+            crate::api::compute_and_update_service_capabilities(pool, &s.name).await
+        {
+            warn!(service = %s.name, error = %e, "could not recompute service modalities");
+        }
     }
 
     if !cfg.mcp_servers.is_empty() {

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -357,7 +357,7 @@ impl Executor {
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
-        let model = self.get_model(&request.model).await?;
+        let model = self.resolve_service_or_model(&request.model).await?;
         let provider = self.get_provider(&model.provider).await?;
         let adapter = self.create_adapter(&provider, &model)?;
 
@@ -404,7 +404,7 @@ impl Executor {
             .check_quota(user_id, 0.01_f64.max(estimated_cost))
             .await?;
 
-        let model = self.get_model(&request.model).await?;
+        let model = self.resolve_service_or_model(&request.model).await?;
         let provider = self.get_provider(&model.provider).await?;
         let adapter = self.create_adapter(&provider, &model)?;
 
@@ -448,7 +448,7 @@ impl Executor {
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
         // Resolve model to provider
-        let model = self.get_model(&request.model).await?;
+        let model = self.resolve_service_or_model(&request.model).await?;
         let provider = self.get_provider(&model.provider).await?;
 
         let adapter = self.create_adapter(&provider, &model)?;
@@ -481,7 +481,7 @@ impl Executor {
         request: &mawi_core::types::SpeechToSpeechRequest,
     ) -> Result<Vec<u8>> {
         // Resolve model to provider
-        let model = self.get_model(&request.model).await?;
+        let model = self.resolve_service_or_model(&request.model).await?;
         let provider = self.get_provider(&model.provider).await?;
 
         let adapter = self.create_adapter(&provider, &model)?;
@@ -508,7 +508,7 @@ impl Executor {
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
-        let model = self.get_model(&request.model).await?;
+        let model = self.resolve_service_or_model(&request.model).await?;
         let provider = self.get_provider(&model.provider).await?;
         let adapter = self.create_adapter(&provider, &model)?;
 
@@ -1471,6 +1471,49 @@ impl Executor {
         self.model_cache.insert(id.to_string(), model.clone()).await;
 
         Ok(model)
+    }
+
+    /// Resolve a name that might be a service OR a model id to a concrete
+    /// model. The non-chat handlers (image / video / TTS / music) take a
+    /// `model` field but ViralStory and the seed YAML address everything
+    /// by service name (`image-default`, `voice-default`, …) — without
+    /// this, every call returned `Model not found: no rows returned`.
+    ///
+    /// Resolution order:
+    ///   1. Try `get_service(name)`. On hit, pick the highest-priority
+    ///      healthy model from its pool and return that.
+    ///   2. Fall through to `get_model(name)` so callers that already
+    ///      pass a real model id keep working.
+    ///
+    /// This is deliberately simpler than the chat path's full
+    /// strategy-aware routing — pool / health / weighted_random etc. for
+    /// images and video would need their own retry / failover wrapper.
+    /// Single-model pick gets ViralStory off the ground; we'll layer
+    /// failover on top once the basic path is exercised in production.
+    pub async fn resolve_service_or_model(
+        &self,
+        name: &str,
+    ) -> Result<mawi_core::models::Model> {
+        match self.get_service(name).await {
+            Ok(_service) => {
+                let models = self.get_service_models_with_weights(name).await?;
+                let (model_id, _provider_id, _weight, _rtcros) = models
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Service '{}' has no healthy models — add one in the admin UI \
+                             or check model_health rows",
+                            name
+                        )
+                    })?;
+                self.get_model(&model_id).await
+            }
+            // Not a service — try direct model lookup. Surface the model
+            // error rather than the service one so misconfigured callers
+            // get the more specific message.
+            Err(_) => self.get_model(name).await,
+        }
     }
 
     async fn update_model_health(

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -1164,7 +1164,14 @@ impl Executor {
 
         let response_text = adapter.chat(&chat_request).await.map_err(|e| {
             eprintln!("Provider call failed: {}", e);
-            anyhow::anyhow!("Provider API error: {}", e)
+            // Preserve the typed ProviderError chain so the chat
+            // handler can downcast and return the correct 4xx
+            // (rate_limit, unauthorized, …) instead of a generic 500.
+            // Stringifying with anyhow!("...: {}", e) would drop the
+            // type info — use `.context()` to add a label without
+            // burning the cause chain.
+            use anyhow::Context as _;
+            e.context("Provider API error")
         })?;
 
         let latency = start.elapsed().as_millis() as i32;

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -513,11 +513,16 @@ impl Executor {
         let adapter = self.create_adapter(&provider, &model)?;
 
         // Rewrite to upstream model name (same fix as TTS / STT).
+        // Forward input_image_url / input_video_url so adapters that
+        // support image-to-video conditioning (Sora 2, Veo, Runway)
+        // see them.
         let upstream_req = mawi_core::types::VideoGenerationRequest {
             prompt: request.prompt.clone(),
             model: model.name.clone(),
             size: request.size.clone(),
             duration: request.duration,
+            input_image_url: request.input_image_url.clone(),
+            input_video_url: request.input_video_url.clone(),
         };
 
         let response = self
@@ -539,14 +544,18 @@ impl Executor {
     }
 
     pub async fn poll_video_job(&self, job_id: &str, model_id: &str) -> Result<serde_json::Value> {
-        let model = self.get_model(model_id).await?;
+        // model_id may arrive as a service name when the original
+        // POST /v1/videos/generations was made with a service. Use
+        // the same resolver as the generation path so the polling
+        // round-trip can find the right adapter.
+        let model = self.resolve_service_or_model(model_id).await?;
         let provider = self.get_provider(&model.provider).await?;
         let adapter = self.create_adapter(&provider, &model)?;
         adapter.poll_video_job(job_id).await
     }
 
     pub async fn get_video_content(&self, generation_id: &str, model_id: &str) -> Result<Vec<u8>> {
-        let model = self.get_model(model_id).await?;
+        let model = self.resolve_service_or_model(model_id).await?;
         let provider = self.get_provider(&model.provider).await?;
         let adapter = self.create_adapter(&provider, &model)?;
         adapter.get_video_content(generation_id).await

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -723,7 +723,7 @@ impl Executor {
         &self,
         request: &mawi_core::types::VideoGenerationRequest,
         user_id: &str,
-    ) -> Result<mawi_core::types::VideoGenerationResponse> {
+    ) -> Result<(mawi_core::models::Model, mawi_core::types::VideoGenerationResponse)> {
         let estimated_cost = crate::pricing::PRICING.get_video_cost(&request.model);
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
@@ -765,7 +765,12 @@ impl Executor {
                     Some(user_id),
                 )
                 .await;
-                Ok(response)
+                // Return the chosen model so the handler can encode it
+                // into the JOB_ID|MODEL: tag — without that, polling
+                // after a failover (Sora unhealthy → Veo handles the
+                // job) would route subsequent polls back to Sora and
+                // 404 every time.
+                Ok((model, response))
             }
             Err(err) => {
                 self.log_modality(

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -400,7 +400,9 @@ impl Executor {
     {
         // Resolve to the candidate list. If the caller passed a
         // model id we get a single-item list; if a service, we get
-        // the pool ordered by position/weight.
+        // the pool ordered by position/weight. Both miss-paths route
+        // through `resolve_service_or_model` so the failed-name
+        // error includes typo suggestions and admin-UI links.
         let models = match self.get_service(service_or_model).await {
             Ok(_) => {
                 let weighted = self
@@ -408,8 +410,10 @@ impl Executor {
                     .await?;
                 if weighted.is_empty() {
                     return Err(anyhow::anyhow!(
-                        "Service '{}' has no healthy models — add one in the admin UI \
-                         or check model_health rows",
+                        "Service '{}' resolved but has no healthy models attached. \
+                         Open the admin UI at /services and add at least one model. \
+                         If models are already attached, check model_health rows — \
+                         every model in the pool may currently be marked unhealthy.",
                         service_or_model
                     ));
                 }
@@ -421,7 +425,7 @@ impl Executor {
                 }
                 out
             }
-            Err(_) => vec![self.get_model(service_or_model).await?],
+            Err(_) => vec![self.resolve_service_or_model(service_or_model).await?],
         };
 
         let mut last_err: Option<anyhow::Error> = None;
@@ -1755,18 +1759,76 @@ impl Executor {
                     .next()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
-                            "Service '{}' has no healthy models — add one in the admin UI \
-                             or check model_health rows",
-                            name
+                            "Service '{}' resolved but has no healthy models attached. \
+                             Open the admin UI at /services, select '{}', and add at least \
+                             one model. If you've already added models, check the model_health \
+                             rows — every model in the pool may currently be marked unhealthy.",
+                            name, name
                         )
                     })?;
                 self.get_model(&model_id).await
             }
-            // Not a service — try direct model lookup. Surface the model
-            // error rather than the service one so misconfigured callers
-            // get the more specific message.
-            Err(_) => self.get_model(name).await,
+            // Not a service — try direct model lookup. If THAT also
+            // fails, we owe the caller a useful error: list the
+            // closest service / model names so a typo is one tap
+            // away from being fixed instead of "no rows returned".
+            Err(_) => match self.get_model(name).await {
+                Ok(m) => Ok(m),
+                Err(_) => {
+                    let suggestions = self.suggest_similar_names(name).await;
+                    Err(anyhow::anyhow!(
+                        "No service or model named '{}' is registered. {}\
+                         Create the service in the admin UI at /services, or POST one via the \
+                         /v1/services API.",
+                        name,
+                        if suggestions.is_empty() {
+                            String::new()
+                        } else {
+                            format!("Did you mean: {}? ", suggestions.join(", "))
+                        }
+                    ))
+                }
+            },
         }
+    }
+
+    /// Fetch up to 3 service / model names whose lowercased prefix
+    /// or suffix matches the requested name. Cheap typo helper —
+    /// turns "image-defualt" → "Did you mean image-default?".
+    async fn suggest_similar_names(&self, requested: &str) -> Vec<String> {
+        let q = requested.to_lowercase();
+        // Match on a 3-char prefix or suffix of the lowercased name —
+        // catches typos and case mismatches without an extension.
+        let prefix = q.chars().take(3).collect::<String>();
+        let suffix = q.chars().rev().take(3).collect::<String>().chars().rev().collect::<String>();
+        let pat_p = format!("{}%", prefix);
+        let pat_s = format!("%{}", suffix);
+
+        let svc: Vec<String> = sqlx::query_scalar(
+            "SELECT name FROM services
+             WHERE lower(name) LIKE $1 OR lower(name) LIKE $2
+             ORDER BY name LIMIT 3",
+        )
+        .bind(&pat_p)
+        .bind(&pat_s)
+        .fetch_all(&self.pool)
+        .await
+        .unwrap_or_default();
+        let mdl: Vec<String> = sqlx::query_scalar(
+            "SELECT id FROM models
+             WHERE lower(id) LIKE $1 OR lower(id) LIKE $2
+             ORDER BY id LIMIT 3",
+        )
+        .bind(&pat_p)
+        .bind(&pat_s)
+        .fetch_all(&self.pool)
+        .await
+        .unwrap_or_default();
+
+        let mut out: Vec<String> = svc.into_iter().chain(mdl).collect();
+        out.sort();
+        out.dedup();
+        out.into_iter().take(3).collect()
     }
 
     async fn update_model_health(
@@ -2168,6 +2230,28 @@ impl Executor {
             env_api_key_for(&provider.provider_type).unwrap_or_default()
         };
 
+        // Pre-flight check — fail with a typed Misconfigured error
+        // before the request is sent. Without this, an empty API key
+        // gets forwarded to the upstream which returns a confusing
+        // 401 ("x-api-key header is required") that the user can't
+        // act on without first reading the gateway logs. Selfhosted
+        // is exempt — Ollama / vLLM commonly run without auth.
+        let provider_type_lc = provider.provider_type.to_lowercase();
+        if api_key.trim().is_empty() && provider_type_lc != "selfhosted" {
+            let env_var = env_var_name_for(&provider_type_lc);
+            return Err(anyhow::Error::new(
+                mawi_core::error::ProviderError::Misconfigured {
+                    provider: provider.provider_type.clone(),
+                    message: format!(
+                        "Provider '{}' has no API key configured. Set it in the admin UI \
+                         (/providers/{}) or export {}={{your-key}} in the gateway's \
+                         environment and restart.",
+                        provider.name, provider.id, env_var
+                    ),
+                },
+            ));
+        }
+
         let base_url = model
             .api_endpoint
             .as_deref()
@@ -2310,6 +2394,32 @@ fn env_api_key_for(provider_type: &str) -> Option<String> {
         _ => return None,
     };
     std::env::var(canonical).ok().filter(|v| !v.is_empty())
+}
+
+/// Pretty version of `env_api_key_for` for error messages — returns
+/// the canonical env var name even for providers whose `env_api_key_for`
+/// returns None (e.g. selfhosted) so the user knows what to set.
+fn env_var_name_for(provider_type: &str) -> &'static str {
+    match provider_type.to_lowercase().as_str() {
+        "openai" => "MG_OPENAI_API_KEY",
+        "azure" => "MG_AZURE_OPENAI_API_KEY",
+        "google" | "gemini" => "MG_GEMINI_API_KEY",
+        "anthropic" => "MG_ANTHROPIC_API_KEY",
+        "xai" => "MG_XAI_API_KEY",
+        "mistral" => "MG_MISTRAL_API_KEY",
+        "perplexity" => "MG_PERPLEXITY_API_KEY",
+        "deepseek" => "MG_DEEPSEEK_API_KEY",
+        "elevenlabs" => "MG_ELEVENLABS_API_KEY",
+        "hume" | "humeai" | "hume-ai" => "MG_HUME_API_KEY",
+        "runway" => "MG_RUNWAY_API_KEY",
+        "kling" | "kuaishou" => "MG_KLING_API_KEY",
+        "luma" | "lumaai" | "luma-ai" => "MG_LUMA_API_KEY",
+        "pika" | "pikalabs" => "MG_PIKA_API_KEY",
+        "minimax" | "hailuo" => "MG_MINIMAX_API_KEY",
+        "bytedance" | "seedance" => "MG_BYTEDANCE_API_KEY",
+        "openrouter" => "MG_OPENROUTER_API_KEY",
+        _ => "MG_<PROVIDER>_API_KEY",
+    }
 }
 
 /// Weighted random pick over a model list. Returns a vec with the

--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -324,7 +324,7 @@ impl Executor {
     /// gets a generic anyhow message.
     async fn with_breaker<T, F, Fut>(&self, model_id: &str, op: F) -> Result<T>
     where
-        F: FnOnce() -> Fut,
+        F: Fn() -> Fut,
         Fut: std::future::Future<Output = Result<T>>,
     {
         if !self.circuit_breaker.allow_request(model_id).await {
@@ -340,10 +340,122 @@ impl Executor {
                 Ok(value)
             }
             Err(err) => {
+                // Single in-place retry when the upstream gave us a
+                // short Retry-After. Honour up to 5s before giving
+                // up — anything longer than that and we'd rather
+                // failover to another model in the pool than block
+                // the request. Counts as ONE retry; if the second
+                // attempt also fails we propagate.
+                if let Some(pe) = mawi_core::error::downcast(&err) {
+                    if let Some(wait) = pe.retry_after() {
+                        if wait <= std::time::Duration::from_secs(5) {
+                            warn!(
+                                model = %model_id,
+                                wait_ms = wait.as_millis() as u64,
+                                "honouring Retry-After then retrying once"
+                            );
+                            tokio::time::sleep(wait).await;
+                            match op().await {
+                                Ok(value) => {
+                                    self.circuit_breaker.record_success(model_id).await;
+                                    return Ok(value);
+                                }
+                                Err(retry_err) => {
+                                    self.circuit_breaker.record_failure(model_id).await;
+                                    return Err(retry_err);
+                                }
+                            }
+                        }
+                    }
+                }
                 self.circuit_breaker.record_failure(model_id).await;
                 Err(err)
             }
         }
+    }
+
+    /// Walk a service's model pool and try each one in priority
+    /// order, recording per-attempt failures and returning the first
+    /// success. Mirrors the chat path's failover but kept simple
+    /// (no strategy switching) for the audio/image/video paths that
+    /// only need "try, on transient error continue".
+    ///
+    /// Skips a model only when the failure is transient — rate-limit,
+    /// timeout, 5xx, or a tripped breaker. Hard failures (400 / 401)
+    /// short-circuit immediately because retrying with a different
+    /// model on the same provider won't help (the request body is
+    /// the problem) and may waste quota.
+    ///
+    /// Returns the *last* error so callers see the most-recent reason
+    /// and the chat handler's typed-error mapping still gets a useful
+    /// `ProviderError`.
+    async fn execute_with_pool_failover<F, Fut, T>(
+        &self,
+        service_or_model: &str,
+        op: F,
+    ) -> Result<(mawi_core::models::Model, T)>
+    where
+        F: Fn(mawi_core::models::Model) -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        // Resolve to the candidate list. If the caller passed a
+        // model id we get a single-item list; if a service, we get
+        // the pool ordered by position/weight.
+        let models = match self.get_service(service_or_model).await {
+            Ok(_) => {
+                let weighted = self
+                    .get_service_models_with_weights(service_or_model)
+                    .await?;
+                if weighted.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "Service '{}' has no healthy models — add one in the admin UI \
+                         or check model_health rows",
+                        service_or_model
+                    ));
+                }
+                let mut out: Vec<mawi_core::models::Model> = Vec::new();
+                for (model_id, _provider_id, _weight, _rtcros) in weighted {
+                    if let Ok(m) = self.get_model(&model_id).await {
+                        out.push(m);
+                    }
+                }
+                out
+            }
+            Err(_) => vec![self.get_model(service_or_model).await?],
+        };
+
+        let mut last_err: Option<anyhow::Error> = None;
+        let total = models.len();
+        for (idx, model) in models.into_iter().enumerate() {
+            match self.with_breaker(&model.id, || op(model.clone())).await {
+                Ok(value) => return Ok((model, value)),
+                Err(err) => {
+                    let is_transient = mawi_core::error::downcast(&err)
+                        .map(|pe| pe.is_retryable())
+                        .unwrap_or(true); // Untyped errors → assume transient
+                    let is_breaker = err.to_string().contains("circuit breaker open");
+                    if !is_transient && !is_breaker {
+                        // Hard failure (bad_request, unauthorized) — don't
+                        // burn through every model on the same provider.
+                        return Err(err);
+                    }
+                    warn!(
+                        model = %model.id,
+                        attempt = idx + 1,
+                        of = total,
+                        error = %err,
+                        "pool failover: transient error, trying next model"
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| {
+            anyhow::anyhow!(
+                "All models in pool '{}' failed; pool was empty or every model errored",
+                service_or_model
+            )
+        }))
     }
 
     /// Execute image generation request
@@ -357,38 +469,62 @@ impl Executor {
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
-        let model = self.resolve_service_or_model(&request.model).await?;
-        let provider = self.get_provider(&model.provider).await?;
-        let adapter = self.create_adapter(&provider, &model)?;
-
-        // Rewrite to upstream model name. Same fix as TTS / STT / video —
-        // the upstream API expects its own model id, not our internal one.
-        let upstream_req = ImageGenerationRequest {
-            prompt: request.prompt.clone(),
-            model: model.name.clone(),
-            n: request.n,
-            size: request.size.clone(),
-            quality: request.quality.clone(),
-            style: request.style.clone(),
-        };
-
-        let response = self
-            .with_breaker(&model.id, || async {
-                adapter.generate_image(&upstream_req).await
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_with_pool_failover(&request.model, |model| {
+                let request = request.clone();
+                async move {
+                    let provider = self.get_provider(&model.provider).await?;
+                    let adapter = self.create_adapter(&provider, &model)?;
+                    let upstream_req = ImageGenerationRequest {
+                        prompt: request.prompt.clone(),
+                        model: model.name.clone(),
+                        n: request.n,
+                        size: request.size.clone(),
+                        quality: request.quality.clone(),
+                        style: request.style.clone(),
+                    };
+                    adapter.generate_image(&upstream_req).await
+                }
             })
-            .await?;
+            .await;
 
-        // Bill for actual images generated
-        let cost =
-            crate::pricing::PRICING.get_image_cost(&request.model, response.data.len() as i64);
-
-        if let Err(e) = quota_manager.charge_user(user_id, cost).await {
-            warn!(error = %e, user_id, "failed to charge user for image gen");
-        } else {
-            debug!(cost, user_id, "charged for image generation");
+        let latency_ms = started.elapsed().as_millis() as i64;
+        match outcome {
+            Ok((model, response)) => {
+                let cost = crate::pricing::PRICING
+                    .get_image_cost(&request.model, response.data.len() as i64);
+                if let Err(e) = quota_manager.charge_user(user_id, cost).await {
+                    warn!(error = %e, user_id, "failed to charge user for image gen");
+                }
+                self.log_modality(
+                    &request.model,
+                    Some(&model.id),
+                    Some(&model.provider),
+                    "success",
+                    None,
+                    cost,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Ok(response)
+            }
+            Err(err) => {
+                self.log_modality(
+                    &request.model,
+                    None,
+                    None,
+                    "error",
+                    Some(&err.to_string()),
+                    0.0,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Err(err)
+            }
         }
-
-        Ok(response)
     }
 
     /// Execute text-to-speech request
@@ -404,35 +540,57 @@ impl Executor {
             .check_quota(user_id, 0.01_f64.max(estimated_cost))
             .await?;
 
-        let model = self.resolve_service_or_model(&request.model).await?;
-        let provider = self.get_provider(&model.provider).await?;
-        let adapter = self.create_adapter(&provider, &model)?;
-
-        // Rewrite the model field to `model.name` (the upstream's actual id)
-        // before handing to the adapter. Without this we forward the
-        // gateway-internal `model.id` to ElevenLabs / Hume / etc., which
-        // surfaces as `An invalid ID has been received: 'eleven-v3'`. The
-        // chat path already does this rewrite (see line ~1077); audio /
-        // video / image paths used to skip it.
-        let upstream_req = mawi_core::types::TextToSpeechRequest {
-            input: request.input.clone(),
-            model: model.name.clone(),
-            voice: request.voice.clone(),
-        };
-
-        let result = self
-            .with_breaker(&model.id, || async {
-                adapter.text_to_speech(&upstream_req).await
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_with_pool_failover(&request.model, |model| {
+                let request = request.clone();
+                async move {
+                    let provider = self.get_provider(&model.provider).await?;
+                    let adapter = self.create_adapter(&provider, &model)?;
+                    let upstream_req = mawi_core::types::TextToSpeechRequest {
+                        input: request.input.clone(),
+                        model: model.name.clone(),
+                        voice: request.voice.clone(),
+                    };
+                    adapter.text_to_speech(&upstream_req).await
+                }
             })
-            .await?;
+            .await;
 
-        if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
-            warn!(error = %e, user_id, "failed to charge user for TTS");
-        } else {
-            debug!(cost = estimated_cost, user_id, "charged for TTS");
+        let latency_ms = started.elapsed().as_millis() as i64;
+        match outcome {
+            Ok((model, result)) => {
+                if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
+                    warn!(error = %e, user_id, "failed to charge user for TTS");
+                }
+                self.log_modality(
+                    &request.model,
+                    Some(&model.id),
+                    Some(&model.provider),
+                    "success",
+                    None,
+                    estimated_cost,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Ok(result)
+            }
+            Err(err) => {
+                self.log_modality(
+                    &request.model,
+                    None,
+                    None,
+                    "error",
+                    Some(&err.to_string()),
+                    0.0,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Err(err)
+            }
         }
-
-        Ok(result)
     }
 
     /// Execute speech-to-text (transcription) request
@@ -447,31 +605,57 @@ impl Executor {
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
-        // Resolve model to provider
-        let model = self.resolve_service_or_model(&request.model).await?;
-        let provider = self.get_provider(&model.provider).await?;
-
-        let adapter = self.create_adapter(&provider, &model)?;
-
-        // Same model.id → model.name rewrite as TTS — see comment there.
-        let upstream_req = mawi_core::types::AudioTranscriptionRequest {
-            model: model.name.clone(),
-            language: request.language.clone(),
-        };
-
-        let result = self
-            .with_breaker(&model.id, || async {
-                adapter.transcribe_audio(audio_data, &upstream_req).await
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_with_pool_failover(&request.model, |model| {
+                let request = request.clone();
+                let audio_data = audio_data.to_vec();
+                async move {
+                    let provider = self.get_provider(&model.provider).await?;
+                    let adapter = self.create_adapter(&provider, &model)?;
+                    let upstream_req = mawi_core::types::AudioTranscriptionRequest {
+                        model: model.name.clone(),
+                        language: request.language.clone(),
+                    };
+                    adapter.transcribe_audio(&audio_data, &upstream_req).await
+                }
             })
-            .await?;
+            .await;
 
-        if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
-            warn!(error = %e, user_id, "failed to charge user for transcription");
-        } else {
-            debug!(cost = estimated_cost, user_id, "charged for transcription");
+        let latency_ms = started.elapsed().as_millis() as i64;
+        match outcome {
+            Ok((model, result)) => {
+                if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
+                    warn!(error = %e, user_id, "failed to charge user for transcription");
+                }
+                self.log_modality(
+                    &request.model,
+                    Some(&model.id),
+                    Some(&model.provider),
+                    "success",
+                    None,
+                    estimated_cost,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Ok(result)
+            }
+            Err(err) => {
+                self.log_modality(
+                    &request.model,
+                    None,
+                    None,
+                    "error",
+                    Some(&err.to_string()),
+                    0.0,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Err(err)
+            }
         }
-
-        Ok(result)
     }
 
     /// Execute speech-to-speech request
@@ -480,22 +664,54 @@ impl Executor {
         audio_data: &[u8],
         request: &mawi_core::types::SpeechToSpeechRequest,
     ) -> Result<Vec<u8>> {
-        // Resolve model to provider
-        let model = self.resolve_service_or_model(&request.model).await?;
-        let provider = self.get_provider(&model.provider).await?;
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_with_pool_failover(&request.model, |model| {
+                let request = request.clone();
+                let audio_data = audio_data.to_vec();
+                async move {
+                    let provider = self.get_provider(&model.provider).await?;
+                    let adapter = self.create_adapter(&provider, &model)?;
+                    let upstream_req = mawi_core::types::SpeechToSpeechRequest {
+                        model: model.name.clone(),
+                        voice: request.voice.clone(),
+                    };
+                    adapter.speech_to_speech(&audio_data, &upstream_req).await
+                }
+            })
+            .await;
 
-        let adapter = self.create_adapter(&provider, &model)?;
-
-        // Rewrite to upstream model name.
-        let upstream_req = mawi_core::types::SpeechToSpeechRequest {
-            model: model.name.clone(),
-            voice: request.voice.clone(),
-        };
-
-        self.with_breaker(&model.id, || async {
-            adapter.speech_to_speech(audio_data, &upstream_req).await
-        })
-        .await
+        let latency_ms = started.elapsed().as_millis() as i64;
+        match outcome {
+            Ok((model, result)) => {
+                self.log_modality(
+                    &request.model,
+                    Some(&model.id),
+                    Some(&model.provider),
+                    "success",
+                    None,
+                    0.0,
+                    latency_ms,
+                    None,
+                )
+                .await;
+                Ok(result)
+            }
+            Err(err) => {
+                self.log_modality(
+                    &request.model,
+                    None,
+                    None,
+                    "error",
+                    Some(&err.to_string()),
+                    0.0,
+                    latency_ms,
+                    None,
+                )
+                .await;
+                Err(err)
+            }
+        }
     }
 
     /// Execute video generation request
@@ -508,39 +724,60 @@ impl Executor {
         let quota_manager = mawi_core::quota::QuotaManager::new(self.pool.clone());
         quota_manager.check_quota(user_id, estimated_cost).await?;
 
-        let model = self.resolve_service_or_model(&request.model).await?;
-        let provider = self.get_provider(&model.provider).await?;
-        let adapter = self.create_adapter(&provider, &model)?;
-
-        // Rewrite to upstream model name (same fix as TTS / STT).
-        // Forward input_image_url / input_video_url so adapters that
-        // support image-to-video conditioning (Sora 2, Veo, Runway)
-        // see them.
-        let upstream_req = mawi_core::types::VideoGenerationRequest {
-            prompt: request.prompt.clone(),
-            model: model.name.clone(),
-            size: request.size.clone(),
-            duration: request.duration,
-            input_image_url: request.input_image_url.clone(),
-            input_video_url: request.input_video_url.clone(),
-        };
-
-        let response = self
-            .with_breaker(&model.id, || async {
-                adapter.generate_video(&upstream_req).await
+        let started = std::time::Instant::now();
+        let outcome = self
+            .execute_with_pool_failover(&request.model, |model| {
+                let request = request.clone();
+                async move {
+                    let provider = self.get_provider(&model.provider).await?;
+                    let adapter = self.create_adapter(&provider, &model)?;
+                    let upstream_req = mawi_core::types::VideoGenerationRequest {
+                        prompt: request.prompt.clone(),
+                        model: model.name.clone(),
+                        size: request.size.clone(),
+                        duration: request.duration,
+                        input_image_url: request.input_image_url.clone(),
+                        input_video_url: request.input_video_url.clone(),
+                    };
+                    adapter.generate_video(&upstream_req).await
+                }
             })
-            .await?;
+            .await;
 
-        if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
-            warn!(error = %e, user_id, "failed to charge user for video");
-        } else {
-            debug!(
-                cost = estimated_cost,
-                user_id, "charged for video generation"
-            );
+        let latency_ms = started.elapsed().as_millis() as i64;
+        match outcome {
+            Ok((model, response)) => {
+                if let Err(e) = quota_manager.charge_user(user_id, estimated_cost).await {
+                    warn!(error = %e, user_id, "failed to charge user for video");
+                }
+                self.log_modality(
+                    &request.model,
+                    Some(&model.id),
+                    Some(&model.provider),
+                    "success",
+                    None,
+                    estimated_cost,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Ok(response)
+            }
+            Err(err) => {
+                self.log_modality(
+                    &request.model,
+                    None,
+                    None,
+                    "error",
+                    Some(&err.to_string()),
+                    0.0,
+                    latency_ms,
+                    Some(user_id),
+                )
+                .await;
+                Err(err)
+            }
         }
-
-        Ok(response)
     }
 
     pub async fn poll_video_job(&self, job_id: &str, model_id: &str) -> Result<serde_json::Value> {
@@ -1841,6 +2078,57 @@ impl Executor {
                 self.quota_worker
                     .charge(uid.to_string(), cost, pool.clone());
             }
+        }
+    }
+
+    /// Slim companion to `log_request` for non-chat modalities.
+    /// `log_request` is coupled to UnifiedChatResponse (carries token
+    /// usage, choices, etc.) which doesn't apply to image / video /
+    /// audio. This helper writes the same `request_logs` row shape
+    /// using just the fields the modality executors actually have:
+    /// service, picked model + provider, status, optional error,
+    /// realised cost, latency. Best-effort — failures to write the
+    /// log don't poison the user's response.
+    pub async fn log_modality(
+        &self,
+        service: &str,
+        model_id: Option<&str>,
+        provider_id: Option<&str>,
+        status: &str,
+        error: Option<&str>,
+        cost_usd: f64,
+        latency_ms: i64,
+        user_id: Option<&str>,
+    ) {
+        // Same key-redaction as log_request: never persist raw API
+        // keys leaking into request_logs even by mistake.
+        let sanitized_error = error.map(|e| {
+            let re_sk = regex::Regex::new(r"sk-[A-Za-z0-9_-]{20,}").unwrap();
+            let re_aiza = regex::Regex::new(r"AIza[A-Za-z0-9_-]{35,}").unwrap();
+            re_aiza.replace_all(&re_sk.replace_all(e, "sk-***"), "AIza***").to_string()
+        });
+
+        let log_id = uuid::Uuid::new_v4().to_string();
+        let res = sqlx::query(
+            "INSERT INTO request_logs (id, virtual_key_id, service_name, model_id, provider_type, \
+             tokens_prompt, tokens_completion, tokens_total, latency_ms, latency_us, status, \
+             error_message, failover_count, cost_usd, user_id) \
+             VALUES ($1, NULL, $2, $3, $4, 0, 0, 0, $5, $6, $7, $8, 0, $9, $10)",
+        )
+        .bind(log_id)
+        .bind(service)
+        .bind(model_id.unwrap_or("unknown"))
+        .bind(provider_id.unwrap_or("unknown"))
+        .bind(latency_ms)
+        .bind(latency_ms * 1000)
+        .bind(status)
+        .bind(sanitized_error)
+        .bind(cost_usd)
+        .bind(user_id)
+        .execute(&self.pool)
+        .await;
+        if let Err(e) = res {
+            tracing::warn!(error = %e, "log_modality insert failed");
         }
     }
 

--- a/backend/gateway/src/main.rs
+++ b/backend/gateway/src/main.rs
@@ -70,6 +70,15 @@ async fn main() -> Result<(), anyhow::Error> {
     // the file they thought was authoritative.
     gateway::config_loader::apply_config_file_if_present(&pool).await?;
 
+    // Recompute input/output modalities for every service from the
+    // current model pool. Idempotent — fixes existing rows that were
+    // written before the modality auto-derivation logic was wired
+    // (or with the old direction-blind audio classifier). Boot
+    // continues even if this fails; logged and reported by counts.
+    if let Err(e) = gateway::api::backfill_all_service_capabilities(&pool).await {
+        tracing::warn!(error = %e, "service modality backfill failed at boot");
+    }
+
     // Start the idempotency-cache cleanup sweeper (#41). Background task,
     // wakes every IDEMPOTENCY_CLEANUP_INTERVAL_SECS (default 1 hour) to
     // delete rows past their TTL. Runs for the lifetime of the process.

--- a/backend/gateway/src/main.rs
+++ b/backend/gateway/src/main.rs
@@ -79,6 +79,14 @@ async fn main() -> Result<(), anyhow::Error> {
         tracing::warn!(error = %e, "service modality backfill failed at boot");
     }
 
+    // Background health-monitor loop. Every 5 minutes pings each
+    // registered model with a tiny request and writes the outcome
+    // into model_health. Without this loop running, the column stays
+    // NULL forever and the admin UI can only show "Not checked",
+    // failover decisions don't have signal, and least-cost / health
+    // routing strategies have no data to work with.
+    gateway::health::HealthMonitor::start(pool.clone());
+
     // Start the idempotency-cache cleanup sweeper (#41). Background task,
     // wakes every IDEMPOTENCY_CLEANUP_INTERVAL_SECS (default 1 hour) to
     // delete rows past their TTL. Runs for the lifetime of the process.

--- a/backend/gateway/src/video.rs
+++ b/backend/gateway/src/video.rs
@@ -50,13 +50,29 @@ pub async fn poll_video_job(
     poem::web::Path((job_id, model_id)): poem::web::Path<(String, String)>,
     executor: Data<&Arc<Executor>>,
 ) -> poem::Result<poem::web::Json<serde_json::Value>> {
-    let status = executor
+    let mut status = executor
         .poll_video_job(&job_id, &model_id)
         .await
         .map_err(|e| {
             tracing::debug!(error = %e, job_id = %job_id, "poll_video_job failed");
             mawi_core::error::into_poem_error(e)
         })?;
+
+    // OpenAI Sora returns a video_url like https://api.openai.com/v1/
+    // videos/<id> that requires the upstream API key on every byte
+    // request — the browser can't reach it directly. Rewrite to the
+    // gateway's own /v1/videos/content/<id>/<model_id> proxy so the
+    // <video src=…> element on the canvas can fetch through the
+    // session it already holds.
+    if let Some(url) = status.get("video_url").and_then(|v| v.as_str()) {
+        if url.starts_with("https://api.openai.com/")
+            || url.contains("api.dev.runwayml.com")
+            || url.contains("api.elevenlabs.io")
+        {
+            let proxied = format!("/v1/videos/content/{}/{}", job_id, model_id);
+            status["video_url"] = serde_json::Value::String(proxied);
+        }
+    }
 
     Ok(poem::web::Json(status))
 }

--- a/backend/gateway/src/video.rs
+++ b/backend/gateway/src/video.rs
@@ -21,13 +21,13 @@ pub async fn generate_video(
             )
         })?;
 
-    eprintln!("🎬 Video generation request for model: {}", req.model);
+    eprintln!("🎬 Video generation request for service: {}", req.model);
     #[cfg(debug_assertions)]
     eprintln!("📝 Prompt: {}", req.prompt);
     #[cfg(not(debug_assertions))]
     eprintln!("📝 Prompt: [REDACTED]");
 
-    let mut response: VideoGenerationResponse = executor
+    let (chosen_model, mut response) = executor
         .execute_video_generation(&req.0, &user.id)
         .await
         .map_err(|e| {
@@ -35,12 +35,21 @@ pub async fn generate_video(
             mawi_core::error::into_poem_error(e)
         })?;
 
-    // Append model ID to job ID for frontend polling
+    // Encode the model that ACTUALLY handled the request (post-
+    // failover) into the JOB_ID tag, NOT the service name. If we
+    // failed over from Sora to Veo and tagged 'video-default', the
+    // poll endpoint would resolve back to Sora (first model in the
+    // pool) and 404 on a Veo job id every single time.
     if let Some(url) = &response.url {
         if url.starts_with("JOB_ID:") {
-            response.url = Some(format!("{}|MODEL:{}", url, req.model));
+            response.url = Some(format!("{}|MODEL:{}", url, chosen_model.id));
         }
     }
+
+    eprintln!(
+        "🎬 Video job created on model '{}' (provider: {})",
+        chosen_model.id, chosen_model.provider
+    );
 
     Ok(Json(response))
 }
@@ -58,17 +67,17 @@ pub async fn poll_video_job(
             mawi_core::error::into_poem_error(e)
         })?;
 
-    // OpenAI Sora returns a video_url like https://api.openai.com/v1/
-    // videos/<id> that requires the upstream API key on every byte
-    // request — the browser can't reach it directly. Rewrite to the
-    // gateway's own /v1/videos/content/<id>/<model_id> proxy so the
-    // <video src=…> element on the canvas can fetch through the
-    // session it already holds.
+    // Always rewrite a non-empty video_url through the gateway's
+    // /v1/videos/content/<id>/<model_id> proxy. Every video provider
+    // returns a URL the browser can't load directly — Sora needs an
+    // OpenAI Bearer header, Veo needs a Google API key as ?key=,
+    // Runway needs a Bearer, ElevenLabs needs xi-api-key, even Pika
+    // and Luma signed CDN URLs sometimes expire faster than the
+    // canvas's load. Routing through the proxy makes "what URL do I
+    // use?" deterministic — gateway always has the right adapter +
+    // credentials, the <video> element only needs to know one path.
     if let Some(url) = status.get("video_url").and_then(|v| v.as_str()) {
-        if url.starts_with("https://api.openai.com/")
-            || url.contains("api.dev.runwayml.com")
-            || url.contains("api.elevenlabs.io")
-        {
+        if !url.is_empty() && !url.starts_with("/v1/videos/content/") {
             let proxied = format!("/v1/videos/content/{}/{}", job_id, model_id);
             status["video_url"] = serde_json::Value::String(proxied);
         }

--- a/frontend/app/playground/page.tsx
+++ b/frontend/app/playground/page.tsx
@@ -16,7 +16,7 @@ interface Service {
     group?: string
     service_type?: string
     description?: string
-    modality?: 'text' | 'multimodal' | 'image' | 'audio' | 'speech-to-text' | 'speech-to-speech' | 'video'
+    modality?: 'text' | 'multimodal' | 'image' | 'audio' | 'music' | 'speech-to-text' | 'speech-to-speech' | 'video'
     system_prompt?: string
     pool_type?: string
     strategy?: string  // Routing strategy (e.g., least_cost, weighted, etc.)
@@ -100,6 +100,23 @@ export default function PlaygroundPage() {
     const messagesEndRef = useRef<HTMLDivElement>(null)
 
     const selectedItem = services.find(s => s.name === selectedService)
+
+    // Audio role disambiguation (shared by submit logic + render).
+    // Models in the DB are tagged with a single `audio` modality
+    // regardless of direction; pull that apart by name so the JSX can
+    // hide the Voice picker on Whisper / music services and the
+    // submit handler can route to the right endpoint. Empty string
+    // when no service is picked yet so the conditionals all evaluate
+    // false safely.
+    const audioRole: 'tts' | 'stt' | 'sts' | 'music' | 'other' = (() => {
+        if (!selectedItem) return 'other'
+        const tag = ((selectedService || '') + ' ' + (selectedItem.label || '')).toLowerCase()
+        if (selectedItem.modality === 'speech-to-text' || /\b(whisper|stt|transcribe)\b/.test(tag)) return 'stt'
+        if (selectedItem.modality === 'speech-to-speech' || /speech-to-speech|\bsts\b/.test(tag)) return 'sts'
+        if (selectedItem.modality === 'music' || /\bmusic\b/.test(tag)) return 'music'
+        if (selectedItem.modality === 'audio') return 'tts'
+        return 'other'
+    })()
 
 
 
@@ -286,6 +303,24 @@ export default function PlaygroundPage() {
                 }
             }
 
+            // Audio direction disambiguation. Models in the DB are
+            // tagged with a single `audio` modality regardless of
+            // whether they speak (TTS) or listen (STT). Use the
+            // model id / service name to pick the right endpoint
+            // before falling into the generic audio branch — same
+            // direction-blind bug pattern as the voice-cinematic
+            // service modality issue.
+            const audioName = (modelId + ' ' + (selectedItem?.label || '')).toLowerCase()
+            const isSpeechToText =
+                selectedItem?.modality === 'speech-to-text' ||
+                /\b(whisper|stt|transcribe)\b/.test(audioName)
+            const isSpeechToSpeech =
+                selectedItem?.modality === 'speech-to-speech' ||
+                /speech-to-speech|\bsts\b/.test(audioName)
+            const isMusicGen =
+                selectedItem?.modality === 'music' ||
+                /\bmusic\b/.test(audioName)
+
             let response
 
             // CRITICAL: AGENTIC services must ALWAYS go through chat/completions
@@ -315,7 +350,7 @@ export default function PlaygroundPage() {
                         prompt: prompt
                     })
                 })
-            } else if (selectedItem?.modality === 'speech-to-text') {
+            } else if (isSpeechToText) {
                 // Speech-to-Text Request
                 if (!audioBlob) {
                     toast.error('Please record or upload audio first')
@@ -364,7 +399,7 @@ export default function PlaygroundPage() {
                     setIsLoading(false)
                 }
                 return
-            } else if (selectedItem?.modality === 'speech-to-speech') {
+            } else if (isSpeechToSpeech) {
                 // Speech-to-Speech Request
                 if (!audioBlob) {
                     toast.error('Please record or upload audio first')
@@ -414,8 +449,22 @@ export default function PlaygroundPage() {
                     setIsLoading(false)
                 }
                 return
+            } else if (isMusicGen) {
+                // Music generation — distinct endpoint from TTS.
+                // ElevenLabs Music takes prompt + music_length_ms;
+                // there's no voice id involved.
+                console.log(`🎵 Sending music request with model ID: "${modelId}"`)
+                response = await fetch('/v1/audio/music', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        prompt,
+                        model: modelId,
+                        music_length_ms: 30_000,
+                    }),
+                })
             } else if (selectedItem?.modality === 'audio') {
-                // Text-to-Speech Request
+                // Text-to-Speech Request (default audio role)
                 console.log(`🎤 Sending TTS request with model ID: "${modelId}"`)
                 response = await fetch('/v1/audio/speech', {
                     method: 'POST',
@@ -851,7 +900,7 @@ export default function PlaygroundPage() {
                                         for cloned voices). Leaving this blank delegates the
                                         choice to whichever provider answers — strictly safer
                                         than sending one provider's id to another. */}
-                                    {(selectedItem?.modality === 'audio' || selectedItem?.modality === 'speech-to-speech') && (
+                                    {(audioRole === 'tts' || audioRole === 'sts') && (
                                         <div className="space-y-2">
                                             <label className="text-sm text-slate-400 flex items-center gap-2">
                                                 Voice
@@ -1248,8 +1297,8 @@ export default function PlaygroundPage() {
 
                             {/* Input Area */}
                             <div className="border-t border-white/10 p-4">
-                                {/* Audio Input for STT/STS models */}
-                                {(selectedItem?.modality === 'speech-to-text' || selectedItem?.modality === 'speech-to-speech') && (
+                                {/* Audio Input for STT / STS models */}
+                                {(audioRole === 'stt' || audioRole === 'sts') && (
                                     <div className="mb-4">
                                         <AudioInput
                                             onAudioReady={setAudioBlob}
@@ -1277,7 +1326,7 @@ export default function PlaygroundPage() {
                                     </div>
                                     <button
                                         type="submit"
-                                        disabled={(selectedItem?.modality === 'speech-to-text' || selectedItem?.modality === 'speech-to-speech' ? !audioBlob : !prompt.trim()) || isLoading || !selectedService}
+                                        disabled={(audioRole === 'stt' || audioRole === 'sts' ? !audioBlob : !prompt.trim()) || isLoading || !selectedService}
                                         title={isLoading ? 'Generating…' : 'Send (Enter)'}
                                         className="shrink-0 inline-flex items-center justify-center gap-2 px-4 rounded-xl
                                                    text-sm font-semibold text-black

--- a/frontend/app/providers/page.tsx
+++ b/frontend/app/providers/page.tsx
@@ -762,7 +762,18 @@ export default function ProvidersPage() {
                   const cpModels = models.filter(m => cpInstances.some(c => c.id === m.provider))
                   const modelCount = cpModels.length
                   const healthyCount = cpModels.filter(m => m.health_status === 'healthy').length
+                  // A model with no health record is "not checked" — distinct
+                  // from "unhealthy". Without this, brand-new models flagged
+                  // the provider card amber even when nothing was actually
+                  // wrong.
+                  const checkedCount = cpModels.filter(m =>
+                    m.health_status === 'healthy' ||
+                    m.health_status === 'warning' ||
+                    m.health_status === 'unhealthy' ||
+                    m.health_status === 'down'
+                  ).length
                   const allHealthy = modelCount > 0 && healthyCount === modelCount
+                  const noneChecked = modelCount > 0 && checkedCount === 0
                   return (
                     <button
                       key={p.id}
@@ -792,17 +803,21 @@ export default function ProvidersPage() {
                             className={`w-1.5 h-1.5 rounded-full ${
                               modelCount === 0
                                 ? 'bg-slate-600'
-                                : allHealthy
-                                  ? 'bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]'
-                                  : 'bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.6)]'
+                                : noneChecked
+                                  ? 'bg-slate-500'
+                                  : allHealthy
+                                    ? 'bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.8)]'
+                                    : 'bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.6)]'
                             }`}
                           />
                           <span>
                             {modelCount === 0
                               ? 'no models'
-                              : allHealthy
-                                ? 'all healthy'
-                                : `${healthyCount}/${modelCount} healthy`}
+                              : noneChecked
+                                ? `${modelCount} model${modelCount === 1 ? '' : 's'} · not checked`
+                                : allHealthy
+                                  ? 'all healthy'
+                                  : `${healthyCount}/${modelCount} healthy`}
                           </span>
                         </span>
                         <span className="text-slate-700">·</span>
@@ -975,7 +990,9 @@ export default function ProvidersPage() {
                                         ? 'success'
                                         : model.health_status === 'warning'
                                           ? 'warning'
-                                          : 'danger'
+                                          : model.health_status === 'unhealthy' || model.health_status === 'down'
+                                            ? 'danger'
+                                            : 'neutral'
                                     }
                                     size="sm"
                                   >
@@ -983,7 +1000,9 @@ export default function ProvidersPage() {
                                       ? 'Active'
                                       : model.health_status === 'warning'
                                         ? 'Warning'
-                                        : 'Down'}
+                                        : model.health_status === 'unhealthy' || model.health_status === 'down'
+                                          ? 'Down'
+                                          : 'Not checked'}
                                   </Badge>
                                 </div>
                                 <div className="text-sm text-slate-400 capitalize">

--- a/frontend/app/services/page.tsx
+++ b/frontend/app/services/page.tsx
@@ -23,6 +23,14 @@ import {
     Code2,
     Database,
     Settings2,
+    Tag,
+    RotateCw,
+    FileText,
+    Image as ImageIcon,
+    AudioLines,
+    Video,
+    Type as TypeIcon,
+    Bot,
 } from 'lucide-react'
 import Link from 'next/link'
 
@@ -240,7 +248,18 @@ export default function ServicesPage() {
             id: m.id,
             label: m.name,
             type: 'model' as const,
-            icon: (m.modality || '').includes('image') ? '🖼️' : (m.modality || '').includes('audio') ? '🎙️' : '🤖',
+            // Modality-distinct Lucide icons. Stay consistent with the
+            // rest of the gateway UI (no emoji as structural icons) and
+            // disambiguate text vs video vs unknown rather than lumping
+            // them all under '🤖'.
+            icon: (() => {
+                const mod = (m.modality || '').toLowerCase();
+                if (mod.includes('image')) return <ImageIcon className="w-4 h-4" />;
+                if (mod.includes('audio')) return <AudioLines className="w-4 h-4" />;
+                if (mod.includes('video')) return <Video className="w-4 h-4" />;
+                if (mod.includes('text')) return <TypeIcon className="w-4 h-4" />;
+                return <Bot className="w-4 h-4" />;
+            })(),
             logo: LOGO_MAP[providerGuess.toLowerCase()]
         }
     })
@@ -924,7 +943,7 @@ export default function ServicesPage() {
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                         placeholder="my-chat-service"
-                        icon={<span>🏷️</span>}
+                        icon={<Tag className="w-4 h-4" strokeWidth={2} />}
                         required
                     />
 
@@ -1075,7 +1094,7 @@ export default function ServicesPage() {
                                     onChange={(e) => setMaxIterations(parseInt(e.target.value) || 10)}
                                     min={1}
                                     max={20}
-                                    icon={<span>🔁</span>}
+                                    icon={<RotateCw className="w-4 h-4" strokeWidth={2} />}
                                 />
                                 <p className="text-xs text-slate-500 mt-1">
                                     Maximum ReAct loop iterations (default: 10)
@@ -1090,7 +1109,7 @@ export default function ServicesPage() {
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
                         placeholder="Service description"
-                        icon={<span>📝</span>}
+                        icon={<FileText className="w-4 h-4" strokeWidth={2} />}
                     />
 
                     <div>
@@ -1450,12 +1469,26 @@ export default function ServicesPage() {
                         <div className="space-y-4">
                             <div className="flex items-center justify-between">
                                 <div className="text-sm font-medium text-slate-400">Assigned Models</div>
-                                {selectedService?.service_type === 'POOL' && (
+                                {selectedService?.service_type === 'POOL' &&
+                                  selectedService?.strategy === 'weighted_random' && (
+                                    // Sum-to-100 only matters for weighted_random.
+                                    // For health (priority-order failover) and none
+                                    // (single-model passthrough), the column is a
+                                    // priority key, not a percentage — flagging it
+                                    // amber there used to mislead operators that a
+                                    // perfectly fine pool was misconfigured.
                                     <div className="flex items-center gap-2 text-xs">
                                         <span className="text-slate-500">Total Weight:</span>
                                         <span className={`font-bold ${serviceModels.reduce((acc, m) => acc + (m.weight || 0), 0) === 100 ? 'text-emerald-400' : 'text-amber-400'}`}>
                                             {serviceModels.reduce((acc, m) => acc + (m.weight || 0), 0)}%
                                         </span>
+                                    </div>
+                                )}
+                                {selectedService?.service_type === 'POOL' &&
+                                  selectedService?.strategy &&
+                                  selectedService?.strategy !== 'weighted_random' && (
+                                    <div className="flex items-center gap-2 text-[11px] text-slate-500">
+                                        <span>Priority order — top to bottom</span>
                                     </div>
                                 )}
                             </div>

--- a/frontend/components/RichPromptEditor.tsx
+++ b/frontend/components/RichPromptEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, ReactNode } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { createPortal } from 'react-dom'
 
@@ -8,7 +8,13 @@ interface Mention {
     id: string
     label: string
     type: 'model' | 'tool'
-    icon?: string
+    /**
+     * Visual marker for the mention. Accepts a string (legacy emoji
+     * paths) or a ReactNode (preferred Lucide icon component) so the
+     * rest of the UI can use vector icons consistently. Renderers
+     * must branch on `typeof icon`.
+     */
+    icon?: string | ReactNode
     logo?: string
     color?: string
 }
@@ -50,7 +56,11 @@ export function RichPromptEditor({ value, onChange, mentions, placeholder, minHe
                 .replace(/\n/g, '<br>')
                 .replace(/\[((?:Model|Tool)):(.*?)\]/g, (match, type, label) => {
                     const mention = mentions.find(m => m.label === label)
-                    const icon = mention?.icon || (type === 'Model' ? '🤖' : '🛠️')
+                    // String fallback for HTML-template contexts (Lucide
+                    // ReactNode icons can't be interpolated into a string —
+                    // they'd render as `[object Object]`).
+                    const rawIcon = mention?.icon
+                    const icon = typeof rawIcon === 'string' ? rawIcon : (type === 'Model' ? '🤖' : '🛠️')
                     const logo = mention?.logo
                     const color = mention?.color || (type === 'Model' ? 'cyan' : 'purple')
                     const bgClass = type === 'Model' ? 'bg-cyan-400/20 text-cyan-400 border-cyan-400/30' : 'bg-purple-400/20 text-purple-400 border-purple-400/30'
@@ -155,7 +165,10 @@ export function RichPromptEditor({ value, onChange, mentions, placeholder, minHe
         }
 
         const type = mention.type === 'model' ? 'Model' : 'Tool'
-        const icon = mention.icon || (type === 'Model' ? '🤖' : '🛠️')
+        // Same string-fallback as the inline-render path; HTML
+        // template strings can't carry a ReactNode.
+        const rawIcon = mention.icon
+        const icon = typeof rawIcon === 'string' ? rawIcon : (type === 'Model' ? '🤖' : '🛠️')
         const bgClass = type === 'Model' ? 'bg-cyan-400/20 text-cyan-400 border-cyan-400/30' : 'bg-purple-400/20 text-purple-400 border-purple-400/30'
 
         const span = document.createElement('span')

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -4,7 +4,12 @@ import { ReactNode } from 'react'
 
 interface BadgeProps {
     children: ReactNode
-    variant?: 'primary' | 'success' | 'warning' | 'danger' | 'purple' | 'cyan'
+    /**
+     * Visual flavour. `neutral` is for "no opinion yet" states (e.g.
+     * health not checked, value not set) — distinct from `danger`
+     * which actively claims something is wrong.
+     */
+    variant?: 'primary' | 'success' | 'warning' | 'danger' | 'purple' | 'cyan' | 'neutral'
     size?: 'sm' | 'md'
     glow?: boolean
 }
@@ -22,6 +27,7 @@ export function Badge({
         danger: 'bg-gradient-to-r from-red-500 to-rose-600 text-white',
         purple: 'bg-gradient-purple text-white',
         cyan: 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/50',
+        neutral: 'bg-slate-500/15 text-slate-300 border border-slate-500/30',
     }
 
     const sizes = {


### PR DESCRIPTION
## Summary
Three independent bugs that together broke every non-chat call from ViralStory to the gateway. Probed end-to-end and verified each fix.

### 1. Service-name resolution in image / video / audio paths
\`/v1/chat/completions\` resolves \`service\` against the services table, but \`/v1/images\`, \`/v1/videos\`, \`/v1/audio/speech\`, and \`/v1/audio/transcriptions\` all called \`get_model(&request.model)\` directly. ViralStory sends service names like \`image-default\`, \`voice-default\` — no such rows exist in \`models\`, so every call returned \`"Model not found: no rows returned by a query that expected to return at least one row"\`.

New \`Executor::resolve_service_or_model\` tries \`get_service\` first, picks the highest-priority healthy model from its pool, and falls through to \`get_model\` if the name doesn't match a service. Six call sites in \`execute_image_generation\` / \`execute_text_to_speech\` / \`execute_speech_to_speech\` / \`execute_video_generation\` / \`execute_transcription\` switched to it.

Intentionally simpler than the chat path's strategy-aware routing — pool / weighted_random / health failover can layer on top once basic resolution works.

### 2. OpenAI image gen was unimplemented
\`OpenAIAdapter\` had no \`generate_image\` override, so DALL-E calls fell through to the trait's default \`"Image generation not supported by this provider"\`. Added the override hitting \`POST /v1/images/generations\` with the standard body shape. Verified — \`image-default\` now returns a real DALL-E URL.

### 3. Sora 2 duration clamp
Sora 2 only accepts 4/8/12 seconds and 400s on anything else with \`"Invalid value: '5'. Supported values are: '4', '8', and '12'."\` ViralStory's canvas picks arbitrary seconds. Clamp the request to the nearest valid value so callers can keep speaking in real seconds.

## Verified probe matrix
All 200 against the running gateway with key set:

| route | status | result |
|-------|--------|--------|
| \`POST /v1/chat/completions\` | 200 | gpt-4o-mini via text-default |
| \`POST /v1/images/generations\` | 200 | DALL-E URL via image-default |
| \`POST /v1/videos/generations\` | 200 | Sora job id via video-default |
| \`POST /v1/audio/speech\` | 200 | mp3 bytes via voice-default |

## Test plan
- [x] \`cargo build -p gateway\` clean
- [x] \`cargo test -p mawi-core --test provider_adapters\` (14 still pass — no test surface change for these adapters)
- [x] Probe matrix above
- [ ] After merge + redeploy, ViralStory canvas should be able to render a video end-to-end (chat plan → DALL-E thumbnail → Sora clip → ElevenLabs voiceover)