### PR TITLE
fix(ci): trivy-action tag must be v0.36.0 not 0.36.0 (closes #109)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@0.36.0
+        # Tag MUST include the leading 'v' — the action publishes
+        # v0.36.0, not 0.36.0. Without the prefix, GitHub Actions
+        # fails with "Unable to resolve action ... unable to find
+        # version 0.36.0" and the whole release pipeline shipped
+        # v0.2.0 without a security scan (#109). Pinned to the
+        # current major; bump deliberately when a new major lands.
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           # Trivy reads these to talk to GHCR. Required while packages are
           # private; harmless when public.


### PR DESCRIPTION
## Summary

Closes #109. v0.2.0 release pipeline shipped images to GHCR without security scans because the Trivy action couldn't be resolved.

## Root cause

\`aquasecurity/trivy-action\` publishes its tags with a \`v\` prefix (\`v0.36.0\`). The release workflow pinned \`@0.36.0\` (no prefix). GitHub Actions failed at the \"Resolve actions\" step:

\`\`\`
Unable to resolve action \`aquasecurity/trivy-action@0.36.0\`,
unable to find version \`0.36.0\`
\`\`\`

Both \`Scan mawi-api\` and \`Scan mawi-web\` jobs silently failed; the workflow continued and pushed images.

## Fix

One-character change (\`@0.36.0\` → \`@v0.36.0\`) plus an inline comment so the next bump remembers the convention.

## Follow-up after merge

Re-tag v0.2.0 (or cut v0.2.1) to get a clean scan run against the currently-deployed images.

## Test plan

- [ ] CI on this branch goes green
- [ ] Push a test tag (e.g. \`v0.0.0-trivy-test\`) and verify both Scan jobs reach Trivy and produce a SARIF