### PR TITLE
feat(ops): GET /v1/version (closes #66)

### DIFF
--- a/backend/gateway/src/health.rs
+++ b/backend/gateway/src/health.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use futures::{stream, StreamExt};
-use poem::{handler, IntoResponse};
+use poem::{handler, web::Json, IntoResponse};
+use serde::Serialize;
 use sqlx::PgPool;
 use std::time::{Duration, Instant};
 use tokio::time::interval;
@@ -8,6 +9,37 @@ use tokio::time::interval;
 #[handler]
 pub fn health_check() -> impl IntoResponse {
     "OK"
+}
+
+/// Build / version info exposed at `GET /v1/version` (#66).
+///
+/// `version` comes from `CARGO_PKG_VERSION` so it tracks the
+/// workspace's published version automatically. `build_sha` and
+/// `build_time` come from env vars set by the Dockerfile / CI
+/// build (`MG_BUILD_SHA`, `MG_BUILD_TIME`); both fall back to
+/// `"unknown"` when missing so local builds and tests still get a
+/// well-formed response.
+///
+/// Useful for: confirming a deploy actually picked up the latest
+/// commit (compare `build_sha` against `git rev-parse HEAD`),
+/// debugging "why does prod still have the old behaviour?", and
+/// building a status page that doesn't have to scrape image labels.
+#[derive(Serialize)]
+pub struct VersionInfo {
+    pub version: &'static str,
+    pub build_sha: String,
+    pub build_time: String,
+    pub rust_target: &'static str,
+}
+
+#[handler]
+pub fn version_info() -> Json<VersionInfo> {
+    Json(VersionInfo {
+        version: env!("CARGO_PKG_VERSION"),
+        build_sha: std::env::var("MG_BUILD_SHA").unwrap_or_else(|_| "unknown".to_string()),
+        build_time: std::env::var("MG_BUILD_TIME").unwrap_or_else(|_| "unknown".to_string()),
+        rust_target: std::env::consts::ARCH,
+    })
 }
 
 #[allow(dead_code)]

--- a/backend/gateway/src/main.rs
+++ b/backend/gateway/src/main.rs
@@ -253,7 +253,11 @@ async fn main() -> Result<(), anyhow::Error> {
         .nest("/", protected_routes)
         .nest("/swagger-ui", ui)
         .at("/spec", poem::endpoint::make_sync(move |_| spec.clone()))
-        .at("/health", get(health::health_check));
+        .at("/health", get(health::health_check))
+        // /v1/version returns build_sha + version + build_time (#66).
+        // Outside the OpenAPI surface for the same reason as /health
+        // and /metrics — operational endpoint, not an API call.
+        .at("/v1/version", get(health::version_info));
 
     // Metrics endpoint — on by default. Opt out with DISABLE_METRICS=true.
     if gateway::metrics::metrics_enabled() {


### PR DESCRIPTION
## Summary

Closes #66. Adds an unauthenticated operational endpoint at \`GET /v1/version\` so operators / status pages / deploy verification can confirm which build is actually running.

## Response shape

\`\`\`json
{
  "version": "0.2.0",
  "build_sha": "abc1234",
  "build_time": "2026-05-06T12:34:56Z",
  "rust_target": "aarch64"
}
\`\`\`

## Sources

| Field | Source | Fallback |
|-------|--------|----------|
| version | \`CARGO_PKG_VERSION\` (compile-time) | always present |
| build_sha | \`MG_BUILD_SHA\` env var | \`"unknown"\` |
| build_time | \`MG_BUILD_TIME\` env var | \`"unknown"\` |
| rust_target | \`std::env::consts::ARCH\` | always present |

Mounted at \`/v1/version\` next to \`/health\` and \`/metrics\` — outside the OpenAPI surface because it's an operator endpoint, not a callable API.

## Follow-up

A small companion PR should wire \`MG_BUILD_SHA\` and \`MG_BUILD_TIME\` into the Dockerfile via \`--build-arg\` and the release workflow's \`docker/build-push-action\` step. Until then, prod responds with \`build_sha: "unknown"\` — the endpoint is functional but uninformative without those vars.

## Depends on

#115 (the cargo fmt CI fix). Without that landing first, CI on this branch will be red on the unrelated fmt drift on develop. Once #115 merges, rebase + force-push will go green.

## Test plan

- [ ] After #115 merges and rebase, CI green
- [ ] \`curl http://localhost:8030/v1/version\` returns the JSON shape
- [ ] Build with \`MG_BUILD_SHA=abc1234 cargo run\` → field reflects it