### PR TITLE
docs: pre-flight + backup + provider matrix (closes #65, #64, #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ MaWi Gateway core will **always be free and open source**. Team and Enterprise e
 
 ## ✨ Features (Community Edition)
 
-- 🔌 **Multi-Provider Support** - OpenAI, Anthropic, Google, Azure, Ollama, and more
-- 🎮 **Interactive Playground** - Test and compare models in real-time
+- 🔌 **Multi-Provider Support** — across every modality (see matrix below)
+- 🎮 **Interactive Playground** — test + compare models in real-time
   
 <img src="docs/images/playground.png" alt="Playground" width="800">
 
-- 📊 **Analytics & Logging** - Track usage, costs, and performance
-- 🌐 **Multimodal Support** - GPT-5, image generation, audio, video
-- 🔗 **MCP Server Integration** - Model Context Protocol support
-- ⚙️ **Service Management** - Create pools, failover, load balancing
-- 🛡️ **Governance** - Access control and guardrails (view-only in Community)
+- 📊 **Analytics & Logging** — track usage, costs, and performance
+- 🌐 **Multimodal Support** — chat, image, audio, video — one gateway
+- 🔗 **MCP Server Integration** — Model Context Protocol support
+- ⚙️ **Service Management** — pools, failover, weighted routing, circuit breakers
+- 🛡️ **Governance** — access control + guardrails (view-only in Community)
+
+### Provider matrix
+
+| Modality | Providers |
+|---------|-----------|
+| **Chat / text** | OpenAI · Anthropic · Google Gemini · Azure OpenAI · xAI · Mistral · Perplexity · DeepSeek · OpenRouter · self-hosted (Ollama / vLLM / llama.cpp) |
+| **Image** | OpenAI (DALL·E, gpt-image) · xAI (Grok Imagine) · Google (Imagen via Gemini) · Azure |
+| **Video** | OpenAI (Sora 2) · Google (Veo 3) · Runway (Gen-3 Alpha) · Kling · Luma (Dream Machine) · Pika · MiniMax (Hailuo) · ByteDance (Seedance) |
+| **Voice (TTS)** | OpenAI · ElevenLabs · Hume (Octave) |
+| **Speech-to-text** | OpenAI (Whisper) · ElevenLabs |
+| **Music** | ElevenLabs Music _(more coming)_ |
+
+API keys live as env vars (e.g. `MG_OPENAI_API_KEY`, `MG_RUNWAY_API_KEY`) or encrypted in the providers table — see [`.env.example`](backend/.env.example).
 
 ## 🚀 Quick Start
 
@@ -40,6 +53,31 @@ docker compose up -d
 open http://localhost:3001
 ```
 
+### Pre-flight checklist (catches the top 5 setup mistakes — #65)
+
+Before `docker compose up -d`, verify each:
+
+- [ ] **Master key generated.** `MG_MASTER_KEY` set in `.env` (32 hex chars):
+      `openssl rand -hex 32 >> .env` then prefix `MG_MASTER_KEY=`. Without
+      it the gateway can't decrypt provider API keys at boot and refuses
+      to start.
+- [ ] **`MG_DATABASE_URL` points at a fresh DB** — defaults are
+      `postgres://mawi:password@mawi-postgres:5432/mawi`. If you're
+      pointing at an existing DB, ensure migrations 001–037 have been
+      applied (run `cargo run -p mawi-cli -- migrate` from `backend/`).
+- [ ] **CORS origins listed.** `MG_CORS_ALLOWED_ORIGINS=http://localhost:3001`
+      (or your frontend's hostname). Without this the admin UI's fetch
+      calls 401 with no error in the browser console.
+- [ ] **Ports free.** `8030` (API), `3001` (admin UI), `5432` (Postgres)
+      must be available. `lsof -i :8030 -i :3001 -i :5432` to check.
+- [ ] **At least one provider key set.** Even `MG_OPENAI_API_KEY` alone is
+      enough to boot — `text-default` and `image-default` services will
+      route there. Without any key, services are healthy at boot but every
+      call 500s with "no API key configured" (#109's pre-flight).
+
+After boot, hit `GET http://localhost:8030/v1/version` to confirm the
+build SHA + version, then `GET /health` for liveness.
+
 ### Manual Setup
 
 ```bash
@@ -53,6 +91,54 @@ cd frontend
 npm install
 npm run dev
 ```
+
+## 💾 Backup & restore (#64)
+
+The gateway's stateful surface is **the Postgres DB only** — providers,
+models, services, request_logs, model_health, encrypted credentials.
+Everything else is reproducible from container images + `.env`.
+
+### Daily snapshot (Docker Compose)
+
+```bash
+docker exec mawi-postgres pg_dump -U mawi -Fc mawi \
+  > backups/mawi-$(date +%Y-%m-%d).dump
+```
+
+`-Fc` is the custom-format dump — smaller, supports parallel restore,
+and works with `pg_restore --jobs=4`.
+
+### Restore on a fresh DB
+
+```bash
+# 1. Bring up an empty DB
+docker compose up -d mawi-postgres
+# 2. Wait for it to be healthy
+docker exec mawi-postgres pg_isready -U mawi
+# 3. Drop + recreate to ensure clean state (DESTRUCTIVE — only on a
+#    confirmed-fresh target)
+docker exec mawi-postgres psql -U mawi -c 'DROP DATABASE IF EXISTS mawi; CREATE DATABASE mawi;'
+# 4. Restore from the snapshot
+docker exec -i mawi-postgres pg_restore -U mawi -d mawi --jobs=4 \
+  < backups/mawi-2026-05-06.dump
+# 5. Boot the gateway — it'll re-apply any newer migrations on top
+docker compose up -d mawi-api
+```
+
+### Critical: keep `MG_MASTER_KEY` with the backup
+
+Provider API keys in the dump are AES-GCM encrypted under
+`MG_MASTER_KEY`. Restoring to a host with a *different* master key
+makes every provider unusable until you re-paste each key in the
+admin UI. **Store the master key in your password manager next to
+the dump.**
+
+### Production: managed Postgres
+
+For prod, point `MG_DATABASE_URL` at a managed instance (RDS / Cloud
+SQL / Supabase / Neon) and use the provider's PITR / scheduled
+snapshots. The gateway has no special backup needs beyond standard
+Postgres.
 
 ## 📚 Documentation
 

--- a/mawigateway.example.yaml
+++ b/mawigateway.example.yaml
@@ -37,6 +37,47 @@ providers:
     type: selfhosted
     api_endpoint: http://localhost:11434
 
+  # ── Image / video / audio providers (#105) ──────────────────────
+  # Uncomment what you have keys for; everything else stays absent
+  # and the loader will skip the matching models below.
+  #
+  # - id: xai
+  #   name: xAI
+  #   type: xai
+  #   api_key_env: MG_XAI_API_KEY
+  # - id: runway
+  #   name: Runway
+  #   type: runway
+  #   api_key_env: MG_RUNWAY_API_KEY
+  # - id: kling
+  #   name: Kling (Kuaishou)
+  #   type: kling
+  #   api_key_env: MG_KLING_API_KEY
+  # - id: lumaai
+  #   name: Luma AI
+  #   type: lumaai
+  #   api_key_env: MG_LUMA_API_KEY
+  # - id: pika
+  #   name: Pika Labs
+  #   type: pika
+  #   api_key_env: MG_PIKA_API_KEY
+  # - id: minimax
+  #   name: MiniMax (Hailuo)
+  #   type: minimax
+  #   api_key_env: MG_MINIMAX_API_KEY
+  # - id: bytedance
+  #   name: ByteDance Seedance
+  #   type: bytedance
+  #   api_key_env: MG_BYTEDANCE_API_KEY
+  # - id: elevenlabs
+  #   name: ElevenLabs
+  #   type: elevenlabs
+  #   api_key_env: MG_ELEVENLABS_API_KEY
+  # - id: hume
+  #   name: Hume AI (Octave)
+  #   type: hume
+  #   api_key_env: MG_HUME_API_KEY
+
 # Models — what gets called. `provider` references a `providers[].id`.
 # Cost fields are optional; leave blank to fall back to the gateway's
 # built-in pricing map.
@@ -76,6 +117,58 @@ models:
     name: llama3
     provider: local-ollama
     modality: text
+
+  # ── Image / video / audio model entries (#105) ──────────────────
+  # Each one needs its provider above (or in the DB) to be usable.
+  #
+  # - id: sora-2
+  #   name: sora-2
+  #   provider: openai
+  #   modality: video
+  # - id: veo-3
+  #   name: veo-3.0-generate-001
+  #   provider: gemini
+  #   modality: video
+  # - id: runway-gen3
+  #   name: gen-3-alpha
+  #   provider: runway
+  #   modality: video
+  # - id: kling-pro
+  #   name: kling-1.6-pro
+  #   provider: kling
+  #   modality: video
+  # - id: luma-dream
+  #   name: dream-machine
+  #   provider: lumaai
+  #   modality: video
+  # - id: pika-15
+  #   name: pika-1.5
+  #   provider: pika
+  #   modality: video
+  # - id: hailuo-01
+  #   name: hailuo-01
+  #   provider: minimax
+  #   modality: video
+  # - id: seedance-1
+  #   name: seedance-1
+  #   provider: bytedance
+  #   modality: video
+  # - id: tts-1
+  #   name: tts-1
+  #   provider: openai
+  #   modality: audio
+  # - id: eleven-v3
+  #   name: eleven_v3
+  #   provider: elevenlabs
+  #   modality: audio
+  # - id: hume-octave
+  #   name: octave-tts
+  #   provider: hume
+  #   modality: audio
+  # - id: whisper-1
+  #   name: whisper-1
+  #   provider: openai
+  #   modality: audio
 
 # Services — what callers send in `request.service`.
 #
@@ -128,6 +221,37 @@ services:
     models:
       - id: dalle-3
         weight: 100
+
+  # ── Video / audio service examples (#105) ───────────────────────
+  # Uncomment after enabling the matching providers + models above.
+  # `health` strategy = priority-order failover: try the first model,
+  # fall over to the next on transient errors (rate_limit, 5xx,
+  # circuit-breaker open). Costs decrease as you walk down the list.
+  #
+  # - name: video-default
+  #   type: pool
+  #   strategy: health
+  #   description: Sora → Veo 3 → Runway → Kling failover
+  #   models:
+  #     - { id: sora-2,      weight: 100 }  # priority 1 (highest quality, slowest)
+  #     - { id: veo-3,       weight: 100 }  # priority 2
+  #     - { id: runway-gen3, weight: 100 }  # priority 3
+  #     - { id: kling-pro,   weight: 100 }  # priority 4 (fastest fallback)
+  #
+  # - name: voice-default
+  #   type: pool
+  #   strategy: weighted_random
+  #   description: Spread TTS load across cheap + premium voices
+  #   models:
+  #     - { id: tts-1,       weight: 50 }   # OpenAI — fast, cheap
+  #     - { id: eleven-v3,   weight: 35 }   # ElevenLabs — best emotion
+  #     - { id: hume-octave, weight: 15 }   # Hume — character voices
+  #
+  # - name: transcribe-default
+  #   type: pool
+  #   strategy: none
+  #   models:
+  #     - { id: whisper-1, weight: 100 }
 
   # Agentic example (declared, basic row upserted now,
   # planner/tool wiring lands in a follow-up PR).


### PR DESCRIPTION
Three docs issues knocked out in one batch — pure docs, no code change.

## Closes

- **#65** Self-hosting README polish — pre-flight checklist (5 items: master key, DB URL, CORS, ports, provider key)
- **#64** Backup story for self-hosted Postgres — pg_dump -Fc daily, pg_restore --jobs=4 restore, MG_MASTER_KEY co-storage warning, managed-Postgres pointer for prod
- **#105** README + mawigateway.example.yaml mention new providers — full provider matrix table, commented-out yaml blocks for xAI / Runway / Kling / Luma / Pika / MiniMax / ByteDance / ElevenLabs / Hume + sample video-default / voice-default / transcribe-default services