### PR TITLE
docs(migrations): self-contained history for 036/037 (closes #111)

### DIFF
--- a/backend/migrations/036_add_video_image_providers.sql
+++ b/backend/migrations/036_add_video_image_providers.sql
@@ -1,19 +1,41 @@
--- Migration 036: previously seeded image/video/audio providers + flagship
--- models so the new adapter code had something to talk to out of the box.
+-- ============================================================================
+-- Migration 036 — INTENTIONAL NO-OP. Read history below before adding to it.
+-- ============================================================================
 --
--- That was wrong: providers are user-managed (the dashboard scopes its
--- listings by user_id), so seeded system rows showed up in the DB without
--- showing up in the UI — confusing and unwanted. We now leave provider
--- registration to the admin UI / mawigateway.yaml / API entirely.
+-- HISTORY (#111). This file went through three states inside a 14-hour
+-- window on 2026-04-29 because the original design decision was wrong:
 --
--- This migration is intentionally empty so anyone who hasn't run the
--- previous version still gets a clean DB. Environments that already ran
--- the seeding version of 036 keep those rows; a follow-up cleanup
--- migration can delete them once we've decided on the right semantics.
+--   v1 (commit 49eed40)  Seeded 8 image/video/audio PROVIDERS + 14 models
+--                        directly into the DB so the new adapter code had
+--                        something to talk to out of the box.
 --
--- The new provider_type strings (runway, kling, lumaai, pika, minimax,
--- bytedance, hume) don't need a migration — provider_type is a free TEXT
--- column. The factory in executor.rs already knows how to instantiate
--- adapters for them.
+--   v2 (commit 4bcfe06)  Rewritten to a no-op `SELECT 1`. Reason: the
+--                        admin UI scopes its provider/model listings by
+--                        user_id (see frontend/app/providers/page.tsx).
+--                        The seeded system rows had user_id = NULL, so
+--                        they existed in the DB but were invisible in
+--                        the UI — confusing operators and impossible
+--                        to delete via the dashboard.
+--
+--   add 037 (55457d4)    Companion migration to delete the rows that
+--                        v1 inserted, in environments that already ran
+--                        v1 before v2 landed.
+--
+-- ============================================================================
+-- Why this file stays as a no-op (instead of being collapsed into 037):
+-- ============================================================================
+--
+-- sqlx records executed migrations by filename hash. Removing 036 would
+-- cause re-applied migrations to skip 037 (because 036 is the
+-- prerequisite in the recorded chain) on environments that ran v1.
+-- Keeping 036 as a no-op preserves the chain integrity.
+--
+-- A future cleanup migration that needs to add real DDL should pick a
+-- new number (038, 039, …) — do NOT re-purpose 036.
+--
+-- The new provider_type strings (xai, runway, kling, lumaai, pika,
+-- minimax, bytedance, hume) don't need DDL — `provider_type` is a free
+-- TEXT column. The factory in executor.rs (`create_adapter`) is the
+-- only place that needs to know about each new type.
 
 SELECT 1; -- no-op so sqlx accepts the file

--- a/backend/migrations/037_remove_036_seeds.sql
+++ b/backend/migrations/037_remove_036_seeds.sql
@@ -1,16 +1,38 @@
--- Migration 037: clean up seed rows that the original version of
--- migration 036 inserted before we made it a no-op.
+-- ============================================================================
+-- Migration 037 — clean up seed rows that the FIRST version of 036 inserted.
+-- ============================================================================
 --
--- Environments that ran the seeding version of 036 already have these
--- rows; environments that ran the no-op version (post-fix) won't see
--- them. Either way this migration is safe to apply: rows are only
--- removed when they look exactly like the seed (NULL user_id, NULL
--- api_key) so we never touch a provider an admin actually configured
--- through the UI / yaml / API.
+-- Why this exists. Migration 036 (see file header) shipped twice within
+-- a day:
 --
--- Models cascade because models.provider_id has ON DELETE CASCADE
--- (see 001_initial_schema), but we delete by id explicitly so the
--- intent is visible in the migration history.
+--   v1: INSERT INTO providers + models for 8 video/image/audio
+--       providers, with NULL user_id (system rows).
+--   v2: rewritten to a no-op `SELECT 1`.
+--
+-- Environments that pulled main between v1 and v2 already have those
+-- rows; the no-op version won't remove them by itself. This migration
+-- is the explicit cleanup.
+--
+-- ============================================================================
+-- SAFETY: the WHERE clauses match ONLY the original seed shape
+-- ============================================================================
+--
+--   user_id IS NULL                ← no admin claimed the row via UI
+--   AND (api_key IS NULL OR '')    ← no admin pasted a real credential
+--
+-- An admin who manually re-added one of these provider ids through
+-- the dashboard / yaml / API would have set user_id to their own id
+-- and (typically) an encrypted api_key — those rows do NOT match
+-- and are preserved.
+--
+-- Models cascade naturally because `models.provider_id REFERENCES
+-- providers(id) ON DELETE CASCADE` (see 001_initial_schema), but we
+-- delete the model rows explicitly first so the migration's intent is
+-- visible without chasing the FK to the providers table.
+--
+-- ============================================================================
+-- Idempotent. Re-running has no effect once the seed rows are gone.
+-- Safe on environments that ran v2 of 036 directly (DELETE matches 0 rows).
 
 DELETE FROM models
  WHERE id IN (


### PR DESCRIPTION
Closes #111. Pure comment additions — no SQL change. Both 036 and 037 now carry their full history in the file header so a fresh contributor doesn't need to read three commit messages to understand why 036 is a no-op and what 037 is cleaning up.