### PR TITLE
feat(health): deep /ready check + spawn HealthMonitor (closes #24, #25)

### DIFF
--- a/backend/gateway/src/health.rs
+++ b/backend/gateway/src/health.rs
@@ -1,21 +1,109 @@
 use anyhow::Result;
 use futures::{stream, StreamExt};
-use poem::{handler, IntoResponse};
+use poem::{handler, http::StatusCode, web::Data, IntoResponse, Response};
 use sqlx::PgPool;
 use std::time::{Duration, Instant};
 use tokio::time::interval;
 
+/// Liveness probe — returns 200 if the process is up. No external deps.
+///
+/// Use this for kubelet `livenessProbe`: it should NOT fail just because
+/// the database is briefly unavailable, otherwise the orchestrator will
+/// kill a pod that would have recovered on its own.
 #[handler]
-pub fn health_check() -> impl IntoResponse {
+pub fn liveness_check() -> impl IntoResponse {
     "OK"
 }
 
-#[allow(dead_code)]
+/// Readiness/health probe — returns 200 only if the gateway can serve
+/// traffic. Currently this means: process up + Postgres reachable.
+///
+/// Closes #24. The previous `/health` returned a literal "OK" with no
+/// dependency check, so a load balancer would happily route requests
+/// to a gateway whose database had fallen over.
+#[handler]
+pub async fn deep_health_check(Data(pool): Data<&PgPool>) -> Response {
+    // Cheap DB round-trip with a short timeout so a wedged DB connection
+    // doesn't block the LB's health pipeline.
+    let probe = tokio::time::timeout(
+        Duration::from_secs(2),
+        sqlx::query_scalar::<_, i32>("SELECT 1").fetch_one(pool),
+    )
+    .await;
+
+    let (status, body) = match probe {
+        Ok(Ok(_)) => (
+            StatusCode::OK,
+            serde_json::json!({ "status": "ok", "checks": { "db": "ok" } }),
+        ),
+        Ok(Err(e)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "degraded",
+                "checks": { "db": "error" },
+                "error": format!("db: {}", e),
+            }),
+        ),
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "degraded",
+                "checks": { "db": "timeout" },
+                "error": "db ping exceeded 2s",
+            }),
+        ),
+    };
+
+    let mut resp = poem::web::Json(body).into_response();
+    resp.set_status(status);
+    resp
+}
+
+/// Backwards-compatible alias for old `/health` callers. Same as
+/// `deep_health_check` — included so existing dashboards and probes
+/// don't break when we add `/live` and `/ready`.
+#[handler]
+pub async fn health_check(pool: Data<&PgPool>) -> Response {
+    deep_health_check_inner(pool.0).await
+}
+
+async fn deep_health_check_inner(pool: &PgPool) -> Response {
+    let probe = tokio::time::timeout(
+        Duration::from_secs(2),
+        sqlx::query_scalar::<_, i32>("SELECT 1").fetch_one(pool),
+    )
+    .await;
+    let (status, body) = match probe {
+        Ok(Ok(_)) => (
+            StatusCode::OK,
+            serde_json::json!({ "status": "ok", "checks": { "db": "ok" } }),
+        ),
+        Ok(Err(e)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "degraded",
+                "checks": { "db": "error" },
+                "error": format!("db: {}", e),
+            }),
+        ),
+        Err(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            serde_json::json!({
+                "status": "degraded",
+                "checks": { "db": "timeout" },
+                "error": "db ping exceeded 2s",
+            }),
+        ),
+    };
+    let mut resp = poem::web::Json(body).into_response();
+    resp.set_status(status);
+    resp
+}
+
 pub struct HealthMonitor {
     pool: PgPool,
 }
 
-#[allow(dead_code)]
 impl HealthMonitor {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
@@ -400,7 +488,6 @@ impl HealthMonitor {
     }
 }
 
-#[allow(dead_code)]
 pub struct HealthStatus {
     pub is_healthy: bool,
     pub response_time_ms: Option<i64>,

--- a/backend/gateway/src/main.rs
+++ b/backend/gateway/src/main.rs
@@ -50,6 +50,11 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing::info!("DATABASE_URL detected (value redacted)");
     let pool = mawi_core::db::init_db(&database_url).await?;
 
+    // Start the background health monitor so model_health stays current.
+    // Without this, health-aware routing (least_latency, health filter)
+    // operates on stale or empty data — closes #25.
+    health::HealthMonitor::start(pool.clone());
+
     // Re-encrypt any plaintext API keys left over from before the #32 fix.
     // After this returns, no provider/model row has a plaintext api_key,
     // and decrypt_key() can refuse plaintext as its default. We log the
@@ -253,6 +258,11 @@ async fn main() -> Result<(), anyhow::Error> {
         .nest("/", protected_routes)
         .nest("/swagger-ui", ui)
         .at("/spec", poem::endpoint::make_sync(move |_| spec.clone()))
+        // /live  — liveness: process up. Cheap, no external deps. (#24)
+        // /ready — readiness/deep health: DB reachable. LBs use this. (#24)
+        // /health — alias for /ready (back-compat with existing probes).
+        .at("/live", get(health::liveness_check))
+        .at("/ready", get(health::deep_health_check))
         .at("/health", get(health::health_check));
 
     // Metrics endpoint — on by default. Opt out with DISABLE_METRICS=true.


### PR DESCRIPTION
## Summary
Two CRITICAL health bugs fixed in one PR (single file pair).

### #24 — /health was a literal \"OK\"
Added two new endpoints + made /health useful:
- **\`/live\`** — process-up liveness, no deps. Use for kubelet \`livenessProbe\`.
- **\`/ready\`** — readiness, pings Postgres with a 2s timeout. Use for LB healthcheck and kubelet \`readinessProbe\`.
- **\`/health\`** — now aliases \`/ready\` (back-compat with existing dashboards/probes).

503 returned on DB down or DB ping timeout. Body shape:
\`\`\`json
{ \"status\": \"ok\" | \"degraded\", \"checks\": { \"db\": \"ok\" | \"error\" | \"timeout\" }, \"error\": \"...\" }
\`\`\`

### #25 — HealthMonitor never spawned
\`HealthMonitor\` was defined and \`#[allow(dead_code)]\`, so model_health was never written. Health-aware routing (least_latency, health filters) operated on stale or empty rows.
- \`main.rs\` now calls \`HealthMonitor::start(pool.clone())\` right after \`init_db\`.
- Removed the \`#[allow(dead_code)]\` markers from the struct, impl block, and HealthStatus.

## Test plan
- [ ] \`curl /live\` → 200 \"OK\" even if DB is wedged (process-up only)
- [ ] \`curl /ready\` with healthy DB → 200, body \`status: ok\`
- [ ] \`curl /ready\` with stopped Postgres → 503, body \`status: degraded\`
- [ ] Boot logs show \"🏥 Health monitor started - checking every 5 minutes\"
- [ ] Wait one tick → \`SELECT * FROM model_health\` returns rows

Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)