### PR TITLE
fix(db): configure SQLx pool with production-tuned defaults (closes #37)

### DIFF
--- a/backend/core/src/db.rs
+++ b/backend/core/src/db.rs
@@ -5,7 +5,8 @@
 //! deploy — cannot race each other on `CREATE TABLE` / `ALTER TABLE`.
 //! See #42.
 
-use sqlx::postgres::PgPool;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::time::Duration;
 
 /// 64-bit advisory-lock key for the migration runner. Arbitrary but
 /// stable: same value across all instances of this codebase, picked to
@@ -14,8 +15,59 @@ use sqlx::postgres::PgPool;
 /// to be debugged in production.
 const MIGRATION_LOCK_KEY: i64 = 0x4d41_5749_4d49_4752;
 
+/// Read a `u32` env var, falling back to `default` on missing/invalid input.
+fn env_u32(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Read a `u64` (seconds) env var, falling back to `default` on missing/invalid input.
+fn env_secs(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Initialise the Postgres pool with production-tuned defaults.
+///
+/// Closes #37 — previously used `PgPool::connect(...)` which gives
+/// SQLx's defaults (~10 max connections, no acquire timeout). Under
+/// modest load the pool starved and requests queued forever.
+///
+/// All limits are env-overridable so operators can tune for their
+/// Postgres tier without rebuilding:
+///   * `MG_DB_MAX_CONNECTIONS`    (default 50)
+///   * `MG_DB_MIN_CONNECTIONS`    (default 5)
+///   * `MG_DB_ACQUIRE_TIMEOUT_S`  (default 5)
+///   * `MG_DB_IDLE_TIMEOUT_S`     (default 600 = 10 min)
+///   * `MG_DB_MAX_LIFETIME_S`     (default 1800 = 30 min)
 pub async fn init_db(database_url: &str) -> Result<PgPool, sqlx::Error> {
-    let pool = PgPool::connect(database_url).await?;
+    let max_conn = env_u32("MG_DB_MAX_CONNECTIONS", 50);
+    let min_conn = env_u32("MG_DB_MIN_CONNECTIONS", 5);
+    let acquire_s = env_secs("MG_DB_ACQUIRE_TIMEOUT_S", 5);
+    let idle_s = env_secs("MG_DB_IDLE_TIMEOUT_S", 600);
+    let lifetime_s = env_secs("MG_DB_MAX_LIFETIME_S", 1800);
+
+    tracing::info!(
+        max_connections = max_conn,
+        min_connections = min_conn,
+        acquire_timeout_s = acquire_s,
+        idle_timeout_s = idle_s,
+        max_lifetime_s = lifetime_s,
+        "configuring Postgres pool"
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(max_conn)
+        .min_connections(min_conn)
+        .acquire_timeout(Duration::from_secs(acquire_s))
+        .idle_timeout(Some(Duration::from_secs(idle_s)))
+        .max_lifetime(Some(Duration::from_secs(lifetime_s)))
+        .connect(database_url)
+        .await?;
     run_migrations(&pool).await?;
     Ok(pool)
 }


### PR DESCRIPTION
## Summary
HIGH: \`init_db\` used \`PgPool::connect(...)\` which gives SQLx defaults (~10 max connections, no acquire timeout). Under modest load the pool starved and requests queued forever.

### New defaults (env-overridable)

| env var | default | purpose |
|---|---|---|
| MG_DB_MAX_CONNECTIONS   | 50   | upper bound on pool size |
| MG_DB_MIN_CONNECTIONS   | 5    | warm pool, avoid cold starts |
| MG_DB_ACQUIRE_TIMEOUT_S | 5    | fail fast when pool is starved |
| MG_DB_IDLE_TIMEOUT_S    | 600  | reap idle conns after 10 min |
| MG_DB_MAX_LIFETIME_S    | 1800 | recycle conns every 30 min |

\`acquire_timeout\` is the most important — without it, a starved pool hangs the request thread until the client gives up. 5s makes pool starvation surface as a clean 5xx instead of a connection drop.

Boot logs include the chosen values.

## Test plan
- [ ] Start gateway, log shows \"configuring Postgres pool max_connections=50 ...\"
- [ ] Set \`MG_DB_MAX_CONNECTIONS=2\`, run a parallel chat-completion workload, verify acquire-timeout error after 5s instead of hang.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)