### PR TITLE
fix(executor): never drop quota charges or audit logs (closes #27, #46)

### DIFF
--- a/backend/gateway/src/executor.rs
+++ b/backend/gateway/src/executor.rs
@@ -100,12 +100,73 @@ impl QuotaWorker {
         Self { sender: tx }
     }
 
+    /// Enqueue a charge.
+    ///
+    /// Closes #27. Pre-fix used `try_send`, which silently dropped charges
+    /// when the 1000-slot channel was full — under sustained load that
+    /// meant free calls. Now:
+    ///   1. Try non-blocking enqueue first (the common case, ~free).
+    ///   2. If full, fall back to a spawned task that `send().await`s so
+    ///      backpressure is absorbed by the worker pool, not the request.
+    ///   3. If even that fails (channel closed at shutdown), do a direct
+    ///      synchronous DB charge so we still bill the user.
+    ///   4. Loud audit-level log if everything fails — surfaces in alerts.
     fn charge(&self, user_id: String, cost: f64, pool: PgPool) {
-        let _ = self.sender.try_send(QuotaTask {
-            user_id,
+        let task = QuotaTask {
+            user_id: user_id.clone(),
             cost,
-            pool,
-        });
+            pool: pool.clone(),
+        };
+        match self.sender.try_send(task) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(task)) => {
+                // Channel full — backpressure into a spawned awaiter so we
+                // don't block the caller's request thread but also don't
+                // drop the charge.
+                let sender = self.sender.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = sender.send(task).await {
+                        // Channel closed (process shutdown). Direct DB charge.
+                        let task = e.0;
+                        tracing::warn!(
+                            user_id = %task.user_id,
+                            cost = task.cost,
+                            "quota channel closed; charging synchronously"
+                        );
+                        let qm = mawi_core::quota::QuotaManager::new(task.pool);
+                        if let Err(err) = qm.charge_user(&task.user_id, task.cost).await {
+                            tracing::error!(
+                                audit = "quota_charge_failed",
+                                user_id = %task.user_id,
+                                cost = task.cost,
+                                error = %err,
+                                "BILLING DROP — failed to charge user (#27 fallback path)"
+                            );
+                        }
+                    }
+                });
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(task)) => {
+                // Same fallback as above — direct DB charge.
+                tokio::spawn(async move {
+                    tracing::warn!(
+                        user_id = %task.user_id,
+                        cost = task.cost,
+                        "quota channel closed; charging synchronously"
+                    );
+                    let qm = mawi_core::quota::QuotaManager::new(task.pool);
+                    if let Err(err) = qm.charge_user(&task.user_id, task.cost).await {
+                        tracing::error!(
+                            audit = "quota_charge_failed",
+                            user_id = %task.user_id,
+                            cost = task.cost,
+                            error = %err,
+                            "BILLING DROP — failed to charge user (#27 fallback path)"
+                        );
+                    }
+                });
+            }
+        }
     }
 }
 
@@ -237,13 +298,42 @@ impl RequestLogger {
         batch.clear();
     }
 
+    /// Log a request.
+    ///
+    /// Closes #46. Pre-fix used `try_send` and incremented a drop counter
+    /// when the 10k-slot channel was full — but for billing/compliance,
+    /// dropped audit entries are not acceptable. Now: backpressure via a
+    /// spawned awaiter, with a synchronous fallback if the channel is
+    /// closed at shutdown.
     pub fn log(&self, pool: PgPool, params: LogParams) {
-        if let Err(_) = self.sender.try_send(LogEntry { pool, params }) {
-            crate::metrics::LOG_DROPS.inc();
-        } else {
-            // Approximate buffer depth (channel capacity - available space)
-            crate::metrics::LOG_BUFFER_DEPTH.set((10000 - self.sender.capacity()) as i64);
+        let entry = LogEntry { pool, params };
+        match self.sender.try_send(entry) {
+            Ok(()) => {
+                crate::metrics::LOG_BUFFER_DEPTH
+                    .set((10000 - self.sender.capacity()) as i64);
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(entry)) => {
+                crate::metrics::LOG_DROPS.inc();
+                let sender = self.sender.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = sender.send(entry).await {
+                        // Channel closed — synchronous fallback insert.
+                        let entry = e.0;
+                        Self::flush_single(entry).await;
+                    }
+                });
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(entry)) => {
+                tokio::spawn(async move { Self::flush_single(entry).await });
+            }
         }
+    }
+
+    /// Synchronous single-row insert — fallback path for #46 when the
+    /// async batch worker is unavailable. Slow but durable.
+    async fn flush_single(entry: LogEntry) {
+        let mut batch = vec![entry];
+        Self::flush_batch(&mut batch).await;
     }
 }
 


### PR DESCRIPTION
## Summary
Two channel-saturation bugs in \`gateway/src/executor.rs\` that silently dropped events under load:

| Issue | Severity | What dropped | Impact |
|---|---|---|---|
| #27 | CRITICAL | quota charges | billing bypass — sustained-load attacker gets free calls |
| #46 | HIGH     | request log entries | billing/compliance gap |

Both used \`mpsc::try_send\` and \`let _ = ...\` / a metrics counter.

### New pattern (applied at both call sites)
1. **Try non-blocking first** — fast path, ~free.
2. **On \`Full\`** — spawn a task that awaits \`send()\`, absorbing backpressure off the request thread.
3. **On \`Closed\`** — spawn a task that does a direct synchronous DB write so events still land at shutdown.
4. **On total failure** — \`tracing::error!(audit = \"quota_charge_failed\", ...)\` for alert pipelines.

The \`LOG_DROPS\` metric is still incremented when the fast path can't enqueue — useful as a saturation signal — but the row is no longer lost.

## Test plan
- [ ] Generate sustained load > 1000 concurrent quota charges; verify \`SELECT current_usage_usd FROM users\` matches expected total (no drops).
- [ ] Same for \`request_logs\` row count.
- [ ] Send SIGTERM mid-flight, verify final entries persist via the synchronous fallback.

Closes #27
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)