### PR TITLE
fix(frontend): replace hardcoded localhost:8030 with API_URL (closes #47)

### DIFF
--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -2,6 +2,7 @@
 
 import Sidebar from '@/components/Sidebar'
 import { ArrowRight } from 'lucide-react'
+import { API_URL } from '@/lib/api'
 
 export default function DocsPage() {
     const endpoints = [
@@ -34,7 +35,7 @@ export default function DocsPage() {
                 <div className="px-10 pb-16 max-w-7xl mx-auto">
                     {/* Swagger Link */}
                     <a
-                        href="http://localhost:8030/swagger-ui"
+                        href={`${API_URL}/swagger-ui`}
                         target="_blank"
                         className="card p-6 block hover:border-gray-700 transition-colors mb-8"
                     >
@@ -68,7 +69,7 @@ export default function DocsPage() {
                     <div className="card p-6 mt-6">
                         <h2 className="text-white font-medium mb-4">Example Request</h2>
                         <pre className="bg-[#0a0a0a] rounded p-4 text-sm text-gray-300 overflow-x-auto">
-                            {`curl -X POST http://localhost:8030/v1/chat/completions \\
+                            {`curl -X POST ${API_URL}/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
     "service": "customer-chat",

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -7,6 +7,7 @@ import { Button, Card, Badge, Input, Modal } from '@/components/ui'
 import { useAuth, fetchModels } from '@/contexts/AuthContext'
 import { toast } from 'sonner'
 import { ShieldCheck, Shield, Activity, ArrowRight } from 'lucide-react'
+import { API_URL } from '@/lib/api'
 
 interface Service {
     id: string
@@ -193,10 +194,10 @@ export default function ProfilePage() {
                                     </div>
                                     <div className="flex items-center gap-2">
                                         <code className="flex-1 bg-black/50 p-2.5 rounded text-sm text-cyan-400 font-mono border border-white/5 truncate">
-                                            http://localhost:8030/v1
+                                            {`${API_URL}/v1`}
                                         </code>
                                         <Button variant="secondary" size="sm" className="shrink-0" onClick={() => {
-                                            navigator.clipboard.writeText('http://localhost:8030/v1')
+                                            navigator.clipboard.writeText(`${API_URL}/v1`)
                                             toast.success('Copied to clipboard')
                                         }}>
                                             Copy

--- a/frontend/app/services/page.tsx
+++ b/frontend/app/services/page.tsx
@@ -25,6 +25,7 @@ import {
     Settings2,
 } from 'lucide-react'
 import Link from 'next/link'
+import { API_URL } from '@/lib/api'
 
 interface Service {
     id?: string
@@ -1394,7 +1395,7 @@ export default function ServicesPage() {
                     </p>
                     <div className="relative group">
                         <pre className="bg-black border border-white/10 rounded-xl p-4 overflow-x-auto text-xs font-mono text-slate-300">
-                            {`curl -X POST http://localhost:8030/v1/chat/completions \\
+                            {`curl -X POST ${API_URL}/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -d '{
@@ -1409,7 +1410,7 @@ export default function ServicesPage() {
                         </pre>
                         <button
                             onClick={() => {
-                                const code = `curl -X POST http://localhost:8030/v1/chat/completions \\
+                                const code = `curl -X POST ${API_URL}/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -d '{

--- a/frontend/components/UserNode.tsx
+++ b/frontend/components/UserNode.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import { useRouter } from 'next/navigation'
 import { User } from 'lucide-react'
+import { API_URL } from '@/lib/api'
 
 export default memo(function UserNode({ data }: any) {
     const router = useRouter()
@@ -39,7 +40,7 @@ export default memo(function UserNode({ data }: any) {
                     )}
 
                     <div className="text-base font-semibold text-white">Incoming Traffic</div>
-                    <div className="text-[10px] text-sky-400/70 font-mono mt-1">http://localhost:8030</div>
+                    <div className="text-[10px] text-sky-400/70 font-mono mt-1">{API_URL}</div>
                 </div>
 
                 {/* Pulse indicator */}


### PR DESCRIPTION
## Summary
HIGH: 4 admin-UI sites hardcoded \`http://localhost:8030\` in user-visible URLs and copy-to-clipboard cURL snippets. Operators behind a reverse proxy or running on non-default hosts saw the wrong endpoint and copy-pasted broken commands.

### Fixed
| File | Was | Now |
|---|---|---|
| \`app/docs/page.tsx\` | Swagger link + cURL example | \`\${API_URL}\` |
| \`app/profile/page.tsx\` | Gateway Endpoint card + Copy button | \`\${API_URL}\` |
| \`app/services/page.tsx\` | Generated cURL snippet (display + copy) | \`\${API_URL}\` |
| \`components/UserNode.tsx\` | Topology label | \`{API_URL}\` |

All sites import the existing \`API_URL\` from \`@/lib/api\`, which reads \`NEXT_PUBLIC_API_URL\` with a \`http://127.0.0.1:8030\` dev fallback (no behavior change for local dev).

## Test plan
- [ ] Set \`NEXT_PUBLIC_API_URL=https://api.example.com\`, rebuild, verify all four locations show the new origin.
- [ ] No \`localhost:8030\` matches under \`frontend/\` (verified by grep).

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)