### PR TITLE
test(circuit-breaker): validate state machine transitions (#82)

### DIFF
--- a/backend/gateway/src/circuit_breaker.rs
+++ b/backend/gateway/src/circuit_breaker.rs
@@ -58,6 +58,30 @@ impl CircuitBreaker {
         }
     }
 
+    /// Test/operator-tunable constructor (#82). The defaults in `new()` are
+    /// production-tuned (3 failures / 60s reset) but tests need much shorter
+    /// timeouts to validate state transitions in milliseconds, and operators
+    /// running smaller fleets may want different thresholds.
+    pub fn with_config(failure_threshold: u32, reset_timeout: Duration) -> Self {
+        let mut cb = Self::new();
+        cb.failure_threshold = failure_threshold;
+        cb.reset_timeout = reset_timeout;
+        cb
+    }
+
+    /// Returns the breaker state for a given resource as a stable string
+    /// (`"closed"`, `"open"`, `"half_open"`, or `"unknown"`). Used by the
+    /// CLI / UI / MCP surface in #82 so operators can see breaker state
+    /// per provider.
+    pub fn state(&self, resource_id: &str) -> &'static str {
+        match self.entries.get(resource_id).map(|e| e.state.clone()) {
+            Some(CircuitState::Closed) => "closed",
+            Some(CircuitState::Open { .. }) => "open",
+            Some(CircuitState::HalfOpen) => "half_open",
+            None => "unknown",
+        }
+    }
+
     /// Check if a request is allowed for a given resource
     pub async fn allow_request(&self, resource_id: &str) -> bool {
         // Fast path: Read-only check
@@ -168,5 +192,100 @@ impl CircuitBreaker {
                 // Already open, refresh valid? maybe not.
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Circuit breaker state-machine tests — closes part of #82.
+    //!
+    //! Verifies the documented transitions:
+    //!   Closed --(N failures)--> Open
+    //!   Open   --(reset_timeout)--> HalfOpen on next allow_request
+    //!   HalfOpen --(success)--> Closed
+    //!   HalfOpen --(failure)--> Open (re-opened immediately)
+    //!
+    //! Tests use `with_config(2, 50ms)` so the half-open transition can
+    //! be validated in real wall time without sleeping for 60s.
+
+    use super::*;
+
+    fn cb() -> CircuitBreaker {
+        CircuitBreaker::with_config(2, Duration::from_millis(50))
+    }
+
+    #[tokio::test]
+    async fn unknown_resource_starts_closed() {
+        let breaker = cb();
+        assert!(breaker.allow_request("openai").await);
+        assert_eq!(breaker.state("openai"), "closed");
+    }
+
+    #[tokio::test]
+    async fn opens_after_threshold_failures() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "closed", "1 failure < threshold");
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "open", "threshold hit");
+        // Open breaker rejects requests.
+        assert!(!breaker.allow_request("openai").await);
+    }
+
+    #[tokio::test]
+    async fn half_opens_after_reset_timeout() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "open");
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        // First call after timeout flips Open -> HalfOpen and is allowed.
+        assert!(breaker.allow_request("openai").await);
+        assert_eq!(breaker.state("openai"), "half_open");
+    }
+
+    #[tokio::test]
+    async fn half_open_success_closes_breaker() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        breaker.record_failure("openai").await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let _ = breaker.allow_request("openai").await; // -> half_open
+        breaker.record_success("openai").await;
+        assert_eq!(breaker.state("openai"), "closed");
+    }
+
+    #[tokio::test]
+    async fn half_open_failure_reopens_breaker() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        breaker.record_failure("openai").await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let _ = breaker.allow_request("openai").await; // -> half_open
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "open");
+    }
+
+    #[tokio::test]
+    async fn success_in_closed_resets_failure_count() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        // 1 failure, still closed; success should reset the counter so
+        // the NEXT failure doesn't immediately trip the breaker.
+        breaker.record_success("openai").await;
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "closed");
+    }
+
+    #[tokio::test]
+    async fn breakers_are_per_resource() {
+        let breaker = cb();
+        breaker.record_failure("openai").await;
+        breaker.record_failure("openai").await;
+        assert_eq!(breaker.state("openai"), "open");
+        // Anthropic should be unaffected.
+        assert_eq!(breaker.state("anthropic"), "unknown");
+        assert!(breaker.allow_request("anthropic").await);
     }
 }


### PR DESCRIPTION
## Summary
First acceptance criterion of #82 — the circuit breaker module had no tests, so its behavior under provider outages was unverifiable.

### What's covered
7 \`#[tokio::test]\` cases for every documented state transition:

| Test | Asserts |
|---|---|
| \`unknown_resource_starts_closed\` | unknown id → \`closed\` + allowed |
| \`opens_after_threshold_failures\` | N failures → \`open\` + rejected |
| \`half_opens_after_reset_timeout\` | \`open\` + sleep > timeout → \`half_open\` |
| \`half_open_success_closes_breaker\` | \`half_open\` + success → \`closed\` |
| \`half_open_failure_reopens_breaker\` | \`half_open\` + failure → \`open\` |
| \`success_in_closed_resets_failure_count\` | success clears partial-trip state |
| \`breakers_are_per_resource\` | openai trip doesn't leak to anthropic |

Tests use \`with_config(2 failures, 50ms reset)\` so half-open transition validates in real wall time without sleeping 60s.

### Public API additions (operator surface for #82)
- \`with_config(threshold, timeout)\` — tunable constructor
- \`state(resource_id) -> &'static str\` — stable string for CLI/UI/MCP display

### Not in this PR
The remaining #82 acceptance criteria are larger lifts and stay open:
- Multi-region routing (region tags + region-aware strategies)
- Per-provider \`circuit_breaker_state{provider=\"...\"}\` metric label (current metric is aggregate counter)
- CLI/UI surfaces using the new \`state()\` accessor

## Test plan
- [ ] \`cargo test -p gateway --lib circuit_breaker::\` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)