### PR TITLE
fix(topology): refresh on tab focus and visibility change (closes #57)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -92,9 +92,32 @@ export default function Home() {
 
   useEffect(() => {
     loadData()
-    // Reduced polling frequency from 8s to 30s to improve performance
+    // Background poll every 30s as a safety net for changes that
+    // happen entirely server-side (e.g. another operator updates a
+    // provider via the CLI).
     const interval = setInterval(loadData, 30000)
-    return () => clearInterval(interval)
+
+    // Refresh-on-focus / visibility-change. Closes #57: an operator
+    // who adds a provider in another tab and switches back here used
+    // to see stale data for up to 30s. Now we refresh as soon as the
+    // tab becomes visible again, so the topology is consistent with
+    // whatever the operator just did.
+    const onFocus = () => {
+      loadData()
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        loadData()
+      }
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      clearInterval(interval)
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
   }, [loadData])
 
   // Authentication Guard


### PR DESCRIPTION
## Summary
The dashboard topology already polls \`/v1/topology\` every 30s, but operators who add a provider/service in another tab and switch back saw stale data for up to 30s.

### Fix
Added two listeners on the existing \`useEffect\`:
- window \`focus\` (tab refocused via Cmd+Tab)
- document \`visibilitychange\` (tab becomes visible)

Both call the same \`loadData\` callback. The 30s background poll stays as a safety net for changes that happen entirely server-side (e.g. another operator running CLI). Listeners are cleaned up on unmount.

## Test plan
- [ ] Open dashboard in Tab A, providers tab in Tab B
- [ ] Add a provider in Tab B
- [ ] Switch to Tab A → topology updates immediately, not after 30s

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)