### PR TITLE
chore(ci): add pre-push gate script + .githooks wrapper (#110)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Thin wrapper so `git config core.hooksPath .githooks` activates the
+# real pre-push gate kept in scripts/ (see #110).
+exec "$(git rev-parse --show-toplevel)/scripts/pre-push.sh" "$@"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,26 @@ npm install
 npm run dev
 ```
 
+### Enable the pre-push gate (recommended)
+
+A pre-push hook in `scripts/pre-push.sh` runs `cargo fmt --check`,
+`cargo check --workspace`, and `cargo clippy -- -D warnings` before
+pushes to `develop` or `main` (other branches are unaffected).
+Closes #110 — without this, partial-bundle pushes have repeatedly
+broken `develop` HEAD.
+
+Activate once per checkout:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Or symlink it directly:
+
+```bash
+ln -s ../../scripts/pre-push.sh .git/hooks/pre-push
+```
+
 ## Code Philosophy
 
 **Rust Backend**:

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Pre-push gate for develop / main — closes #110.
+#
+# Without this hook, partial-bundle pushes have repeatedly broken
+# develop HEAD: a fresh clone in those windows fails `cargo check`
+# and crashes a fresh DB at runtime. See #110 for the three commits
+# that explicitly fixed this within 24h.
+#
+# Install (one-time, per checkout):
+#
+#     git config core.hooksPath .githooks
+#
+# …or symlink directly:
+#
+#     ln -s ../../scripts/pre-push.sh .git/hooks/pre-push
+#
+# To skip in an emergency (NOT for normal use):
+#
+#     git push --no-verify
+#
+# This script is a no-op for branches other than develop / main, so
+# WIP feature branches are unaffected.
+
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+
+# Read the refs being pushed (hook contract: STDIN gives lines of
+# "<local_ref> <local_sha> <remote_ref> <remote_sha>")
+PROTECTED=0
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/develop|refs/heads/main)
+      PROTECTED=1
+      ;;
+  esac
+done
+
+if [ "$PROTECTED" -eq 0 ]; then
+  exit 0
+fi
+
+echo "[pre-push] develop/main detected — running gate checks…"
+
+cd "$(git rev-parse --show-toplevel)/backend"
+
+echo "[pre-push] cargo fmt --all -- --check"
+cargo fmt --all -- --check
+
+echo "[pre-push] cargo check --workspace --all-targets"
+cargo check --workspace --all-targets
+
+echo "[pre-push] cargo clippy --workspace --all-targets -- -D warnings"
+cargo clippy --workspace --all-targets -- -D warnings || {
+  echo "[pre-push] clippy failed — fix the lints or push to a feature branch and let CI handle it"
+  exit 1
+}
+
+echo "[pre-push] OK"


### PR DESCRIPTION
## Summary
Closes the local-enforcement half of #110. Branch protection still has to be configured by a repo admin, but this lands what contributors can opt into now.

### What's added
- **\`scripts/pre-push.sh\`** — no-op for feature branches; on pushes to develop/main runs:
  - \`cargo fmt --all -- --check\`
  - \`cargo check --workspace --all-targets\`
  - \`cargo clippy --workspace --all-targets -- -D warnings\`
- **\`.githooks/pre-push\`** — wrapper so \`git config core.hooksPath .githooks\` activates the script
- **\`CONTRIBUTING.md\`** — one-line activation instructions

### Why
Three commits in 24h on develop (3a87122, 36ba0c4, 8cbe187) were explicitly self-described as fixing prior partial-bundle pushes that broke develop HEAD. A fresh clone in those windows failed \`cargo check\`. CI being permanently red (#108) made it invisible.

The hook is opt-in — no surprise \`cargo build\` blocking pushes for people who haven't run \`git config core.hooksPath .githooks\`. Bypassable with \`--no-verify\` for emergencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)